### PR TITLE
Fix snapshotter not forgetting removed files

### DIFF
--- a/astacus/node/snapshotter.py
+++ b/astacus/node/snapshotter.py
@@ -218,6 +218,11 @@ class Snapshotter:
             # making extra symlinks and we can just use the src
             # directory contents as-is.
             dst_dirs, dst_files = src_dirs, src_files
+            # When the src and dst files are identical, we can't compare the files of the previous
+            # snapshot, but we still need to cleanup outdated files in relative_path_to_snapshotfile.
+            relative_dst_files = {dst_file.relative_path for dst_file in dst_files}
+            for outdated_relative_path in set(self.relative_path_to_snapshotfile) - relative_dst_files:
+                self._remove_snapshotfile(self.relative_path_to_snapshotfile[outdated_relative_path])
         else:
             progress.add_total(3)
             dst_dirs, dst_files = self._list_dirs_and_files(self.dst)

--- a/tests/unit/node/test_snapshotter.py
+++ b/tests/unit/node/test_snapshotter.py
@@ -1,0 +1,23 @@
+"""
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+"""
+from astacus.common.progress import Progress
+from astacus.common.snapshot import SnapshotGroup
+from astacus.node.snapshotter import Snapshotter
+from pathlib import Path
+
+
+def test_snapshotter_with_src_equal_dst_forgets_file_from_previous_snapshot(tmp_path: Path) -> None:
+    src_and_dst = tmp_path
+    file_before = src_and_dst / "file_before"
+    file_before.write_bytes(b"x" * 1024)
+    snapshotter = Snapshotter(src=src_and_dst, dst=src_and_dst, groups=[SnapshotGroup(root_glob="*")], parallel=1)
+    with snapshotter.lock:
+        snapshotter.snapshot(progress=Progress())
+        assert snapshotter.relative_path_to_snapshotfile.keys() == {Path("file_before")}
+        file_before.unlink()
+        file_after = src_and_dst / "file_after"
+        file_after.write_bytes(b"y" * 1024)
+        snapshotter.snapshot(progress=Progress())
+        assert snapshotter.relative_path_to_snapshotfile.keys() == {Path("file_after")}


### PR DESCRIPTION
When using the `src==dst` mode of the snapshotter, the `relative_path_to_snapshotfile` mutable member keeps remembering files that don't exist anymore.

This variable is read after the snapshot and then used to select which files to upload. Since these files don't exist anymore, they can't be uploaded and the backup fails.