### PR TITLE
Bring Cassandra to a known state before restoring

### DIFF
--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -195,6 +195,7 @@ class SnapshotClearRequest(NodeRequest):
 class CassandraSubOp(StrEnum):
     get_schema_hash = "get-schema-hash"
     remove_snapshot = "remove-snapshot"
+    remove_keyspaces = "remove-keyspaces"
     restore_snapshot = "restore-snapshot"
     restore_snapshot_with_schema = "restore-snapshot-with-schema"
     start_cassandra = "start-cassandra"

--- a/astacus/coordinator/plugins/cassandra/plugin.py
+++ b/astacus/coordinator/plugins/cassandra/plugin.py
@@ -115,6 +115,7 @@ class CassandraPlugin(CoordinatorPlugin):
             base.BackupManifestStep(json_storage=context.json_storage),
             restore_steps.ParsePluginManifestStep(),
             base.MapNodesStep(partial_restore_nodes=req.partial_restore_nodes),
+            CassandraRestoreSubOpStep(op=ipc.CassandraSubOp.stop_cassandra),
             CassandraRestoreSubOpStep(op=ipc.CassandraSubOp.remove_keyspaces),
         ] + cluster_restore_steps
 

--- a/astacus/coordinator/plugins/cassandra/plugin.py
+++ b/astacus/coordinator/plugins/cassandra/plugin.py
@@ -115,6 +115,7 @@ class CassandraPlugin(CoordinatorPlugin):
             base.BackupManifestStep(json_storage=context.json_storage),
             restore_steps.ParsePluginManifestStep(),
             base.MapNodesStep(partial_restore_nodes=req.partial_restore_nodes),
+            CassandraRestoreSubOpStep(op=ipc.CassandraSubOp.remove_keyspaces),
         ] + cluster_restore_steps
 
     def get_restore_schema_from_snapshot_steps(self, *, context: OperationContext, req: ipc.RestoreRequest) -> List[Step]:

--- a/astacus/node/config.py
+++ b/astacus/node/config.py
@@ -4,6 +4,7 @@ See LICENSE for details
 """
 
 from astacus.common.cassandra.config import CassandraClientConfiguration
+from astacus.common.magic import StrEnum
 from astacus.common.rohmustorage import RohmuConfig
 from astacus.common.statsd import StatsdConfig
 from astacus.common.utils import AstacusModel
@@ -22,6 +23,11 @@ class NodeParallel(AstacusModel):
     uploads: int = 1
 
 
+class CassandraAccessLevel(StrEnum):
+    read = "read"
+    write = "write"
+
+
 class CassandraNodeConfig(AstacusModel):
     # Used in subop=get-schema-hash
     client: CassandraClientConfiguration
@@ -34,6 +40,10 @@ class CassandraNodeConfig(AstacusModel):
     # (arguments passed as-is to subprocess.run)
     start_command: List[str]
     stop_command: List[str]
+
+    # We might want to block some damaging operations to avoid accidentally destroying live data.
+    # Specify a safe default, let the users override it when restoring.
+    access_level: CassandraAccessLevel = CassandraAccessLevel.read
 
     @classmethod
     @validator("client")

--- a/tests/unit/node/test_node_cassandra.py
+++ b/tests/unit/node/test_node_cassandra.py
@@ -5,7 +5,8 @@ See LICENSE for details
 
 from astacus.common import ipc
 from astacus.common.cassandra.config import SNAPSHOT_NAME
-from astacus.node.config import CassandraNodeConfig
+from astacus.node.api import READONLY_SUBOPS
+from astacus.node.config import CassandraAccessLevel, CassandraNodeConfig
 from tests.unit.conftest import CassandraTestConfig
 
 import pytest
@@ -39,6 +40,7 @@ class CassandraTestEnv(CassandraTestConfig):
             nodetool_command=["nodetool"],
             start_command=["dummy-start"],
             stop_command=["dummy-stop"],
+            access_level=CassandraAccessLevel.write,
         )
         self.app.state.node_config.cassandra = self.cassandra_node_config
 
@@ -151,3 +153,13 @@ def test_api_cassandra_get_schema_hash(ctenv, fail, mocker):
         assert not schema_hash
     else:
         assert schema_hash == "mockhash"
+
+
+@pytest.mark.parametrize("dangerous_op", set(ipc.CassandraSubOp) - READONLY_SUBOPS)
+def test_dangerous_ops_not_allowed_on_read_access_level(ctenv, dangerous_op: ipc.CassandraSubOp):
+    pytest.importorskip("astacus.node.cassandra")
+    ctenv.lock()
+    ctenv.setup_cassandra_node_config()
+    ctenv.cassandra_node_config.access_level = CassandraAccessLevel.read
+    response = ctenv.post(subop=dangerous_op, json={})
+    assert response.status_code == 403, response.json()

--- a/tests/unit/node/test_node_cassandra.py
+++ b/tests/unit/node/test_node_cassandra.py
@@ -89,6 +89,9 @@ def test_api_cassandra_subop(app, ctenv, mocker, subop):
     if subop == ipc.CassandraSubOp.remove_snapshot:
         assert not ctenv.snapshot_path.exists()
         assert ctenv.other_snapshot_path.exists()
+    elif subop == ipc.CassandraSubOp.remove_keyspaces:
+        assert (ctenv.root / "data").exists()
+        assert not (ctenv.root / "data" / "dummyks").exists()
     elif subop == ipc.CassandraSubOp.restore_snapshot:
         # The file should be moved from dummytable-123 snapshot dir to
         # dummytable-234


### PR DESCRIPTION
To avoid restore retries to fail in a loop, because the previous attempt left something in the data directory, stop Cassandra and clean the data directory before attempting restoration. To avoid accidentally deleting live node data, blacklist potentially damaging restore operations by default. Blacklist should be explicitly reset when configuring a node to perform restoration.