### PR TITLE
clickhouse: copy object storage files on restore

### DIFF
--- a/astacus/coordinator/plugins/clickhouse/async_object_storage.py
+++ b/astacus/coordinator/plugins/clickhouse/async_object_storage.py
@@ -4,10 +4,12 @@ See LICENSE for details
 """
 from abc import ABC, abstractmethod
 from pathlib import Path
+from rohmu import BaseTransfer
 from rohmu.errors import FileNotFoundFromStorageError
 from starlette.concurrency import run_in_threadpool
-from typing import Any, Mapping
+from typing import Any, Iterator, Mapping, Self, Sequence
 
+import contextlib
 import dataclasses
 import datetime
 import logging
@@ -36,6 +38,10 @@ class AsyncObjectStorage(ABC):
     async def delete_item(self, key: Path) -> None:
         ...
 
+    @abstractmethod
+    async def copy_items_from(self, source: "AsyncObjectStorage", keys: Sequence[Path]) -> None:
+        ...
+
 
 class ThreadSafeRohmuStorage:
     def __init__(self, config: Mapping[str, Any]) -> None:
@@ -50,6 +56,20 @@ class ThreadSafeRohmuStorage:
     def delete_key(self, key: str) -> None:
         with self._storage_lock:
             self._storage.delete_key(key)
+
+    def copy_items_from(self, source: "ThreadSafeRohmuStorage", keys: Sequence[str]) -> None:
+        # In theory this could deadlock if some other place was locking the same two storages
+        # in the reverse order at the same time. Within the context of backups and restore,
+        # it's quite unlikely to have a pair of storages be the source and target of each other.
+        # Especially since we create new storage objects for each coordinator operation.
+        with source.get_storage() as source_storage:
+            with self.get_storage() as target_storage:
+                target_storage.copy_files_from(source=source_storage, keys=keys)
+
+    @contextlib.contextmanager
+    def get_storage(self) -> Iterator[BaseTransfer]:
+        with self._storage_lock:
+            yield self._storage
 
 
 @dataclasses.dataclass(frozen=True)
@@ -66,21 +86,41 @@ class RohmuAsyncObjectStorage(AsyncObjectStorage):
     async def delete_item(self, key: Path) -> None:
         await run_in_threadpool(self.storage.delete_key, str(key))
 
+    async def copy_items_from(self, source: "AsyncObjectStorage", keys: Sequence[Path]) -> None:
+        if not isinstance(source, RohmuAsyncObjectStorage):
+            raise NotImplementedError("Copying items is only supported from another RohmuAsyncObjectStorage")
+        str_keys = [str(key) for key in keys]
+        await run_in_threadpool(self.storage.copy_items_from, source.storage, str_keys)
+
 
 @dataclasses.dataclass(frozen=True)
 class MemoryAsyncObjectStorage(AsyncObjectStorage):
-    items: list[ObjectStorageItem]
+    items: dict[Path, ObjectStorageItem] = dataclasses.field(default_factory=dict)
+
+    @classmethod
+    def from_items(cls, items: Sequence[ObjectStorageItem]) -> Self:
+        return cls(items={item.key: item for item in items})
 
     def get_config(self) -> Mapping[str, Any]:
-        return {}
+        # Exposing the object id in the config ensures that the same memory storage
+        # has the same config as itself and a different config as another memory storage.
+        # Using a manually picked name would be more error-prone: we want two object
+        # storages to share state when their config is equal (= they are reading and
+        # writing to the same place), that wouldn't happen with two identically named
+        # *memory* object storages.
+        return {"memory_id": id(self)}
 
     async def list_items(self) -> list[ObjectStorageItem]:
-        return self.items[:]
+        return list(self.items.values())
 
     async def delete_item(self, key: Path) -> None:
-        for item in self.items:
-            if item.key == key:
-                logger.info("deleting item: %r", key)
-                self.items.remove(item)
-                return
-        raise FileNotFoundFromStorageError(key)
+        if key not in self.items:
+            raise FileNotFoundFromStorageError(key)
+        logger.info("deleting item: %r", key)
+        self.items.pop(key)
+
+    async def copy_items_from(self, source: "AsyncObjectStorage", keys: Sequence[Path]) -> None:
+        keys_set = set(keys)
+        for source_item in await source.list_items():
+            if source_item.key in keys_set:
+                self.items[source_item.key] = source_item

--- a/astacus/coordinator/plugins/clickhouse/disks.py
+++ b/astacus/coordinator/plugins/clickhouse/disks.py
@@ -28,17 +28,13 @@ class Disk:
     object_storage: AsyncObjectStorage | None = None
 
     @classmethod
-    def from_disk_config(cls, config: DiskConfiguration) -> "Disk":
+    def from_disk_config(cls, config: DiskConfiguration, storage_name: str | None = None) -> "Disk":
         if config.object_storage is None:
             object_storage: RohmuAsyncObjectStorage | None = None
         else:
-            object_storage = RohmuAsyncObjectStorage(
-                storage=ThreadSafeRohmuStorage(
-                    config=config.object_storage.storages[config.object_storage.default_storage].dict(
-                        by_alias=True, exclude_unset=True
-                    )
-                )
-            )
+            config_name = storage_name if storage_name is not None else config.object_storage.default_storage
+            storage_config = config.object_storage.storages[config_name].dict(by_alias=True, exclude_unset=True)
+            object_storage = RohmuAsyncObjectStorage(storage=ThreadSafeRohmuStorage(config=storage_config))
         return Disk(
             type=config.type,
             name=config.name,
@@ -150,10 +146,10 @@ class Disks:
         )
 
     @classmethod
-    def from_disk_configs(cls, disk_configs: Sequence[DiskConfiguration]) -> "DiskPaths":
-        return DiskPaths(
+    def from_disk_configs(cls, disk_configs: Sequence[DiskConfiguration], storage_name: str | None = None) -> "Disks":
+        return Disks(
             disks=sorted(
-                [Disk.from_disk_config(disk_config) for disk_config in disk_configs],
+                [Disk.from_disk_config(disk_config, storage_name) for disk_config in disk_configs],
                 key=lambda disk: len(disk.path_parts),
                 reverse=True,
             )

--- a/astacus/coordinator/plugins/clickhouse/disks.py
+++ b/astacus/coordinator/plugins/clickhouse/disks.py
@@ -72,7 +72,7 @@ class ParsedPath:
 
 
 @dataclasses.dataclass(frozen=True)
-class DiskPaths:
+class Disks:
     disks: Sequence[Disk] = dataclasses.field(
         default_factory=lambda: [Disk(type=DiskType.local, name="default", path_parts=())]
     )

--- a/astacus/coordinator/plugins/clickhouse/parts.py
+++ b/astacus/coordinator/plugins/clickhouse/parts.py
@@ -7,7 +7,7 @@ Replicated family of table engines.
 
 This does not support shards, but this is the right place to add support for them.
 """
-from .disks import DiskPaths
+from .disks import Disks
 from .manifest import Table
 from astacus.common.ipc import SnapshotFile, SnapshotResult
 from typing import AbstractSet, Iterable, Mapping, Optional, Sequence, Set, Tuple
@@ -60,7 +60,7 @@ def get_part_servers(part_files: Iterable[PartFile]) -> AbstractSet[int]:
 
 def list_parts_to_attach(
     snapshot_result: SnapshotResult,
-    disk_paths: DiskPaths,
+    disks: Disks,
     tables_by_uuid: Mapping[uuid.UUID, Table],
 ) -> Sequence[Tuple[str, bytes]]:
     """
@@ -69,7 +69,7 @@ def list_parts_to_attach(
     parts_to_attach: Set[Tuple[str, bytes]] = set()
     assert snapshot_result.state is not None
     for snapshot_file in snapshot_result.state.files:
-        parsed_path = disk_paths.parse_part_file_path(snapshot_file.relative_path)
+        parsed_path = disks.parse_part_file_path(snapshot_file.relative_path)
         table = tables_by_uuid.get(parsed_path.table_uuid)
         if table is not None:
             parts_to_attach.add((table.escaped_sql_identifier, parsed_path.part_name))

--- a/astacus/coordinator/plugins/clickhouse/plugin.py
+++ b/astacus/coordinator/plugins/clickhouse/plugin.py
@@ -22,6 +22,7 @@ from .steps import (
     PrepareClickHouseManifestStep,
     RemoveFrozenTablesStep,
     RestoreAccessEntitiesStep,
+    RestoreObjectStorageFilesStep,
     RestoreReplicaStep,
     RestoreReplicatedDatabasesStep,
     RetrieveAccessEntitiesStep,
@@ -138,6 +139,7 @@ class ClickHousePlugin(CoordinatorPlugin):
         zookeeper_client = get_zookeeper_client(self.zookeeper)
         clients = get_clickhouse_clients(self.clickhouse)
         disks = Disks.from_disk_configs(self.disks)
+        source_disks = Disks.from_disk_configs(self.disks, storage_name=context.storage_name)
         return [
             ValidateConfigStep(clickhouse=self.clickhouse),
             BackupNameStep(json_storage=context.json_storage, requested_name=req.name),
@@ -161,6 +163,7 @@ class ClickHousePlugin(CoordinatorPlugin):
             ),
             MapNodesStep(partial_restore_nodes=req.partial_restore_nodes),
             RestoreStep(storage_name=context.storage_name, partial_restore_nodes=req.partial_restore_nodes),
+            RestoreObjectStorageFilesStep(source_disks=source_disks, target_disks=disks),
             AttachMergeTreePartsStep(
                 clients=clients,
                 disks=disks,

--- a/requirements.testing.txt
+++ b/requirements.testing.txt
@@ -18,7 +18,7 @@ mypy==1.0.0
 types-PyYAML>=6.0.12.2
 types-tabulate>=0.9.0.0
 types-urllib3>=1.26.25.4
-typing_extensions>=4.4.0
+typing_extensions>=4.7.1
 
 freezegun>=1.2
 respx==0.20.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,10 +13,10 @@ install_requires =
   fastapi==0.86.0
   httpx==0.22.0
   protobuf==3.19.4
-  rohmu==1.1.0
+  rohmu==1.1.3
   sentry-sdk==1.6.0
   tabulate==0.9.0
-  typing-extensions==4.4.0
+  typing-extensions==4.7.1
   uvicorn==0.15.0
   # Pinned transitive deps
   pydantic==1.10.2

--- a/tests/unit/coordinator/plugins/clickhouse/test_disks.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_disks.py
@@ -2,11 +2,37 @@
 Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
+from astacus.common.rohmustorage import RohmuLocalStorageConfig, RohmuStorageType
 from astacus.common.snapshot import SnapshotGroup
-from astacus.coordinator.plugins.clickhouse.config import DiskConfiguration, DiskType
+from astacus.coordinator.plugins.clickhouse.config import DiskConfiguration, DiskObjectStorageConfiguration, DiskType
 from astacus.coordinator.plugins.clickhouse.disks import Disk, Disks, ParsedPath, PartFilePathError
 from pathlib import Path
 from uuid import UUID
+
+import pytest
+
+SAMPLE_DEFAULT_DISK_CONFIGURATION = DiskConfiguration(type=DiskType.local, path=Path(), name="default")
+SAMPLE_SECONDARY_DISK_CONFIGURATION = DiskConfiguration(
+    type=DiskType.object_storage,
+    path=Path("disks/secondary"),
+    name="secondary",
+    object_storage=DiskObjectStorageConfiguration(
+        default_storage="default",
+        # We're using local storage here because it's the only storage type
+        # that does not try to do operation during its __init__...
+        storages={
+            "default": RohmuLocalStorageConfig(
+                storage_type=RohmuStorageType.local,
+                directory="default-bucket",
+            ),
+            "recovery": RohmuLocalStorageConfig(
+                storage_type=RohmuStorageType.local,
+                directory="recovery-bucket",
+            ),
+        },
+    ),
+)
+SAMPLE_DISKS_CONFIGURATION = [SAMPLE_DEFAULT_DISK_CONFIGURATION, SAMPLE_SECONDARY_DISK_CONFIGURATION]
 
 
 def test_get_snapshot_groups_pattern_escapes_backup_name() -> None:
@@ -145,3 +171,23 @@ def test_other_disk_parsed_path_to_path() -> None:
         part_name=b"all_1_1_0",
         file_parts=("checksum.txt",),
     ).to_path() == Path("disks/secondary/store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt")
+
+
+def test_disk_can_load_default_object_storage_config() -> None:
+    disk = Disk.from_disk_config(SAMPLE_SECONDARY_DISK_CONFIGURATION)
+    assert disk.object_storage.get_config()["directory"] == "default-bucket"
+
+
+def test_disk_can_load_alternate_object_storage_config() -> None:
+    disk = Disk.from_disk_config(SAMPLE_SECONDARY_DISK_CONFIGURATION, storage_name="recovery")
+    assert disk.object_storage.get_config()["directory"] == "recovery-bucket"
+
+
+def test_disks_can_load_default_object_storage_config() -> None:
+    disks = Disks.from_disk_configs(SAMPLE_DISKS_CONFIGURATION)
+    assert disks.get_object_storage(disk_name="secondary").get_config()["directory"] == "default-bucket"
+
+
+def test_disks_can_load_alternate_object_storage_config() -> None:
+    disks = Disks.from_disk_configs(SAMPLE_DISKS_CONFIGURATION, storage_name="recovery")
+    assert disks.get_object_storage(disk_name="secondary").get_config()["directory"] == "recovery-bucket"

--- a/tests/unit/coordinator/plugins/clickhouse/test_disks.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_disks.py
@@ -4,23 +4,21 @@ See LICENSE for details
 """
 from astacus.common.snapshot import SnapshotGroup
 from astacus.coordinator.plugins.clickhouse.config import DiskConfiguration, DiskType
-from astacus.coordinator.plugins.clickhouse.disks import Disk, DiskPaths, ParsedPath
+from astacus.coordinator.plugins.clickhouse.disks import Disk, Disks, ParsedPath
 from pathlib import Path
 from uuid import UUID
 
 
 def test_get_snapshot_groups_pattern_escapes_backup_name() -> None:
-    disk_paths = DiskPaths()
-    assert disk_paths.get_snapshot_groups("something+stra/../nge") == [
+    disks = Disks()
+    assert disks.get_snapshot_groups("something+stra/../nge") == [
         SnapshotGroup(root_glob="shadow/something%2Bstra%2F%2E%2E%2Fnge/store/**/*")
     ]
 
 
 def test_parse_part_file_path() -> None:
-    disk_paths = DiskPaths()
-    parsed_path = disk_paths.parse_part_file_path(
-        Path("store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt")
-    )
+    disks = Disks()
+    parsed_path = disks.parse_part_file_path(Path("store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt"))
     assert parsed_path == ParsedPath(
         disk=Disk(type=DiskType.local, name="default", path_parts=()),
         freeze_name=None,
@@ -32,8 +30,8 @@ def test_parse_part_file_path() -> None:
 
 
 def test_parse_detached_part_file_path() -> None:
-    disk_paths = DiskPaths()
-    parsed_path = disk_paths.parse_part_file_path(
+    disks = Disks()
+    parsed_path = disks.parse_part_file_path(
         Path("store/123/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt")
     )
     assert parsed_path == ParsedPath(
@@ -47,8 +45,8 @@ def test_parse_detached_part_file_path() -> None:
 
 
 def test_parse_shadow_part_file_path() -> None:
-    disk_paths = DiskPaths()
-    parsed_path = disk_paths.parse_part_file_path(
+    disks = Disks()
+    parsed_path = disks.parse_part_file_path(
         Path("shadow/astacus/store/123/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt")
     )
     assert parsed_path == ParsedPath(
@@ -62,13 +60,13 @@ def test_parse_shadow_part_file_path() -> None:
 
 
 def test_parse_part_file_path_on_other_disk() -> None:
-    disk_paths = DiskPaths.from_disk_configs(
+    disks = Disks.from_disk_configs(
         [
             DiskConfiguration(type=DiskType.local, path=Path(), name="default"),
             DiskConfiguration(type=DiskType.object_storage, path=Path("disks/secondary"), name="secondary"),
         ]
     )
-    parsed_path = disk_paths.parse_part_file_path(
+    parsed_path = disks.parse_part_file_path(
         Path("disks/secondary/store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt")
     )
     assert parsed_path == ParsedPath(

--- a/tests/unit/coordinator/plugins/clickhouse/test_parts.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_parts.py
@@ -3,7 +3,7 @@ Copyright (c) 2021 Aiven Ltd
 See LICENSE for details
 """
 from astacus.common.ipc import SnapshotFile, SnapshotResult, SnapshotState
-from astacus.coordinator.plugins.clickhouse.disks import DiskPaths
+from astacus.coordinator.plugins.clickhouse.disks import Disks
 from astacus.coordinator.plugins.clickhouse.manifest import Table
 from astacus.coordinator.plugins.clickhouse.parts import get_part_servers, list_parts_to_attach, Part, PartFile
 from astacus.coordinator.plugins.clickhouse.replication import DatabaseReplica
@@ -72,7 +72,7 @@ def test_get_part_servers_fails_on_inconsistent_servers_set() -> None:
 def test_list_parts_to_attach() -> None:
     parts_to_attach = list_parts_to_attach(
         SnapshotResult(state=SnapshotState(files=TABLE_1_PART_1 + TABLE_1_PART_2)),
-        DiskPaths(),
+        Disks(),
         {
             T1_UUID: Table(
                 database=b"default",

--- a/tests/unit/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_steps.py
@@ -1090,8 +1090,8 @@ def check_each_pair_of_calls_has_the_same_session_id(mock_calls: Sequence[MockCa
 
 @pytest.mark.asyncio
 async def test_delete_object_storage_files_step(tmp_path: Path) -> None:
-    object_storage = MemoryAsyncObjectStorage(
-        items=[
+    object_storage = MemoryAsyncObjectStorage.from_items(
+        [
             ObjectStorageItem(
                 key=Path("not_used/and_old"), last_modified=datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
             ),


### PR DESCRIPTION
When restoring from an object storage that is different from the default one,
copy files from the restoring storage config to the default storage config.

This adds support for restoring tables using object storage files
as well as tables using local storage.

This relies on an unmerged version of romhu to allow copying files
between buckets.