### PR TITLE
Keep Cassandra snapshot when retrying restore

### DIFF
--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -195,7 +195,7 @@ class SnapshotClearRequest(NodeRequest):
 class CassandraSubOp(StrEnum):
     get_schema_hash = "get-schema-hash"
     remove_snapshot = "remove-snapshot"
-    remove_keyspaces = "remove-keyspaces"
+    unrestore_snapshot = "unrestore-snapshot"
     restore_snapshot = "restore-snapshot"
     restore_snapshot_with_schema = "restore-snapshot-with-schema"
     start_cassandra = "start-cassandra"

--- a/astacus/coordinator/plugins/cassandra/plugin.py
+++ b/astacus/coordinator/plugins/cassandra/plugin.py
@@ -116,7 +116,7 @@ class CassandraPlugin(CoordinatorPlugin):
             restore_steps.ParsePluginManifestStep(),
             base.MapNodesStep(partial_restore_nodes=req.partial_restore_nodes),
             CassandraRestoreSubOpStep(op=ipc.CassandraSubOp.stop_cassandra),
-            CassandraRestoreSubOpStep(op=ipc.CassandraSubOp.remove_keyspaces),
+            CassandraRestoreSubOpStep(op=ipc.CassandraSubOp.unrestore_snapshot),
         ] + cluster_restore_steps
 
     def get_restore_schema_from_snapshot_steps(self, *, context: OperationContext, req: ipc.RestoreRequest) -> List[Step]:

--- a/tests/unit/node/test_node_cassandra.py
+++ b/tests/unit/node/test_node_cassandra.py
@@ -91,9 +91,12 @@ def test_api_cassandra_subop(app, ctenv, mocker, subop):
     if subop == ipc.CassandraSubOp.remove_snapshot:
         assert not ctenv.snapshot_path.exists()
         assert ctenv.other_snapshot_path.exists()
-    elif subop == ipc.CassandraSubOp.remove_keyspaces:
+    elif subop == ipc.CassandraSubOp.unrestore_snapshot:
         assert (ctenv.root / "data").exists()
-        assert not (ctenv.root / "data" / "dummyks").exists()
+        assert (ctenv.root / "data" / "dummyks").exists()
+        assert (ctenv.root / "data" / "dummyks" / "dummytable-123").exists()
+        assert [p.name for p in (ctenv.root / "data" / "dummyks" / "dummytable-123").iterdir()] == ["snapshots"]
+        assert not (ctenv.root / "data" / "dummyks" / "dummytable-234").exists()
     elif subop == ipc.CassandraSubOp.restore_snapshot:
         # The file should be moved from dummytable-123 snapshot dir to
         # dummytable-234


### PR DESCRIPTION
Snapshot contents are managed by the Snapshotter class, there's no need to re-download it on error. Make the "remove-keyspaces" subop more sophisticated, instruct Astacus to clear everything except the snapshot and incremental backup directories (will be used once we implement incremental backup/restore for Cassandra). This makes sure that we start the restore process with a clean data directory, no leftovers from previous restore attempts.