### PR TITLE
Log operation progress on coordinator

### DIFF
--- a/astacus/coordinator/cluster.py
+++ b/astacus/coordinator/cluster.py
@@ -16,6 +16,7 @@ import copy
 import httpx
 import json
 import logging
+import urllib.parse
 
 logger = logging.getLogger(__name__)
 
@@ -194,6 +195,8 @@ class Cluster:
                 # TBD: This could be done in parallel too
                 if result is not None and result.progress.final:
                     continue
+                progress_text = f"{result.progress!r}" if result is not None else "not started"
+                logger.info("%s node #%d/%d: %s", node_op_from_url(url), i, len(urls), progress_text)
                 r = await utils.httpx_request(
                     url, caller="Nodes.wait_successful_results", timeout=self.poll_config.result_timeout
                 )
@@ -221,3 +224,8 @@ class Cluster:
 
 class WaitResultError(Exception):
     pass
+
+
+def node_op_from_url(url: str) -> str:
+    parsed_url = urllib.parse.urlparse(url)
+    return parsed_url.path.replace("/node/", "")

--- a/astacus/coordinator/cluster.py
+++ b/astacus/coordinator/cluster.py
@@ -163,11 +163,7 @@ class Cluster:
         return rv
 
     async def wait_successful_results(
-        self,
-        *,
-        start_results: Sequence[Optional[Result]],
-        result_class: Type[NR],
-        required_successes: Optional[int] = None,
+        self, *, start_results: Sequence[Optional[Result]], result_class: Type[NR]
     ) -> List[NR]:
         urls = []
 
@@ -179,8 +175,8 @@ class Cluster:
                 raise WaitResultError(f"incorrect start result for #{i}/{len(start_results)}: {start_result!r}")
             parsed_start_result = op.Op.StartResult.parse_obj(start_result)
             urls.append(parsed_start_result.status_url)
-        if required_successes is not None and len(urls) != required_successes:
-            raise WaitResultError(f"incorrect number of results: {len(urls)} vs {required_successes}")
+        if len(urls) != len(start_results):
+            raise WaitResultError(f"incorrect number of results: {len(urls)} vs {len(start_results)}")
         results: List[Optional[NR]] = [None] * len(urls)
         # Note that we don't have timeout mechanism here as such,
         # however, if re-locking times out, we will bail out. TBD if

--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -119,9 +119,7 @@ class SnapshotStep(Step[List[ipc.SnapshotResult]]):
                 root_globs=[group.root_glob for group in self.snapshot_groups],
             )
         start_results = await cluster.request_from_nodes("snapshot", method="post", caller="SnapshotStep", req=req)
-        return await cluster.wait_successful_results(
-            start_results=start_results, result_class=ipc.SnapshotResult, required_successes=len(start_results)
-        )
+        return await cluster.wait_successful_results(start_results=start_results, result_class=ipc.SnapshotResult)
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
When performing cluster operations, the coordinator is waiting for a
certain NodeResult to be returned by the operation status request. But
the logs contain no traces of the NodeResult visible on the coordinator
side. As a result, when an operation takes longer than expected, all
we see in the coordinator logs is a few repeated outgoing status
requests followed by the operation failure. Even if we match the
outgoing requests to the node HTTP server logs, we observe only 200
response codes, but don't see the status inside the request body.

To make operation progress more visible in the coordinator logs, add
intermediate operation result logging in the wait_successful_results
function. This way we can see what the coordinator is waiting for and
try to match this with the logs on the misbehaving node.