### PR TITLE
Implement delta backups for Cassandra, part 1

### DIFF
--- a/astacus/common/magic.py
+++ b/astacus/common/magic.py
@@ -31,3 +31,4 @@ class ErrorCode(StrEnum):
 
 # In storage, json files with this prefix are backup manifests
 JSON_BACKUP_PREFIX = "backup-"
+JSON_DELTA_PREFIX = "delta-"

--- a/astacus/coordinator/coordinator.py
+++ b/astacus/coordinator/coordinator.py
@@ -325,6 +325,17 @@ class BackupOp(SteppedCoordinatorOp):
         super().__init__(c=c, attempts=c.config.backup_attempts, steps=steps)
 
 
+class DeltaBackupOp(SteppedCoordinatorOp):
+    @staticmethod
+    async def create(*, c: Coordinator = Depends()) -> "DeltaBackupOp":
+        return DeltaBackupOp(c=c)
+
+    def __init__(self, *, c: Coordinator) -> None:
+        context = c.get_operation_context()
+        steps = c.get_plugin().get_delta_backup_steps(context=context)
+        super().__init__(c=c, attempts=c.config.backup_attempts, steps=steps)
+
+
 class RestoreOp(SteppedCoordinatorOp):
     @staticmethod
     async def create(*, c: Coordinator = Depends(), req: ipc.RestoreRequest = ipc.RestoreRequest()) -> "RestoreOp":

--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -77,11 +77,6 @@ class StepsContext:
         self.attempt_start = utils.now() if attempt_start is None else attempt_start
         self.step_results: Dict[Type[Step], Any] = {}
 
-    @property
-    def backup_name(self) -> str:
-        iso = self.attempt_start.isoformat(timespec="seconds")
-        return f"{magic.JSON_BACKUP_PREFIX}{iso}"
-
     def get_result(self, step_class: Type[Step[T]]) -> T:
         return self.step_results[step_class]
 
@@ -102,6 +97,7 @@ class SnapshotStep(Step[List[ipc.SnapshotResult]]):
     """
 
     snapshot_groups: Sequence[SnapshotGroup]
+    snapshot_request: str = "snapshot"
 
     async def run_step(self, cluster: Cluster, context: StepsContext) -> List[ipc.SnapshotResult]:
         nodes_metadata = await get_nodes_metadata(cluster)
@@ -121,7 +117,9 @@ class SnapshotStep(Step[List[ipc.SnapshotResult]]):
             req = ipc.SnapshotRequest(
                 root_globs=[group.root_glob for group in self.snapshot_groups],
             )
-        start_results = await cluster.request_from_nodes("snapshot", method="post", caller="SnapshotStep", req=req)
+        start_results = await cluster.request_from_nodes(
+            self.snapshot_request, method="post", caller="SnapshotStep", req=req
+        )
         return await cluster.wait_successful_results(start_results=start_results, result_class=ipc.SnapshotResult)
 
 
@@ -155,10 +153,12 @@ class UploadBlocksStep(Step[List[ipc.SnapshotUploadResult]]):
 
     storage_name: str
     validate_file_hashes: bool = True
+    upload_request: str = "upload"
+    list_hexdigests_step: type[Step[Set[str]]] = ListHexdigestsStep
 
     async def run_step(self, cluster: Cluster, context: StepsContext) -> List[ipc.SnapshotUploadResult]:
         node_index_datas = build_node_index_datas(
-            hexdigests=context.get_result(ListHexdigestsStep),
+            hexdigests=context.get_result(self.list_hexdigests_step),
             snapshots=context.get_result(SnapshotStep),
             node_indices=list(range(len(cluster.nodes))),
         )
@@ -167,7 +167,28 @@ class UploadBlocksStep(Step[List[ipc.SnapshotUploadResult]]):
             self.storage_name,
             node_index_datas,
             validate_file_hashes=self.validate_file_hashes,
+            upload_request=self.upload_request,
         )
+
+
+@dataclasses.dataclass
+class SnapshotClearStep(Step[List[ipc.NodeResult]]):
+    """
+    Request to clear the source hierarchy of the snapshotter on all nodes.
+
+    Depending on the request, this can clear either the main snapshotter or the delta snapshotter.
+    """
+
+    clear_request: str = "clear"
+
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> List[ipc.NodeResult]:
+        snapshot_results = context.get_result(SnapshotStep)
+        assert snapshot_results[0].state
+        node_request = ipc.SnapshotClearRequest(root_globs=snapshot_results[0].state.root_globs)
+        start_results = await cluster.request_from_nodes(
+            self.clear_request, method="post", caller="SnapshotClearStep", req=node_request
+        )
+        return await cluster.wait_successful_results(start_results=start_results, result_class=ipc.NodeResult)
 
 
 @dataclasses.dataclass
@@ -184,6 +205,7 @@ class UploadManifestStep(Step[None]):
     plugin_manifest_step: Optional[Type[Step[Dict]]] = None
     snapshot_step: Optional[Type[Step[List[ipc.SnapshotResult]]]] = SnapshotStep
     upload_step: Optional[Type[Step[List[ipc.SnapshotUploadResult]]]] = UploadBlocksStep
+    backup_prefix: str = magic.JSON_BACKUP_PREFIX
 
     async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
         plugin_data = context.get_result(self.plugin_manifest_step) if self.plugin_manifest_step else {}
@@ -201,7 +223,7 @@ class UploadManifestStep(Step[None]):
 
     def _make_backup_name(self, context: StepsContext) -> str:
         iso = context.attempt_start.isoformat(timespec="seconds")
-        return f"{magic.JSON_BACKUP_PREFIX}{iso}"
+        return f"{self.backup_prefix}{iso}"
 
 
 @dataclasses.dataclass
@@ -545,7 +567,7 @@ class NodeIndexData(utils.AstacusModel):
 
 
 def build_node_index_datas(
-    *, hexdigests, snapshots: List[ipc.SnapshotResult], node_indices: List[int]
+    *, hexdigests: Set[str], snapshots: List[ipc.SnapshotResult], node_indices: List[int]
 ) -> List[NodeIndexData]:
     assert len(snapshots) == len(node_indices)
     sshash_to_node_indexes: Dict[ipc.SnapshotHash, List[int]] = {}
@@ -573,7 +595,11 @@ def build_node_index_datas(
 
 
 async def upload_node_index_datas(
-    cluster: Cluster, storage_name: str, node_index_datas: List[NodeIndexData], validate_file_hashes: bool
+    cluster: Cluster,
+    storage_name: str,
+    node_index_datas: List[NodeIndexData],
+    validate_file_hashes: bool,
+    upload_request: str,
 ):
     logger.info("upload_node_index_datas")
     start_results: List[Optional[Result]] = []
@@ -586,7 +612,7 @@ async def upload_node_index_datas(
         else:
             req = ipc.SnapshotUploadRequest(hashes=data.sshashes, storage=storage_name)
         start_result = await cluster.request_from_nodes(
-            "upload", caller="upload_node_index_datas", method="post", req=req, nodes=[cluster.nodes[data.node_index]]
+            upload_request, caller="upload_node_index_datas", method="post", req=req, nodes=[cluster.nodes[data.node_index]]
         )
         if len(start_result) != 1:
             raise StepFailedError("upload failed")

--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -192,8 +192,13 @@ class UploadManifestStep(Step[None]):
             plugin=self.plugin,
             plugin_data=plugin_data,
         )
-        logger.info("Storing backup manifest %s", context.backup_name)
-        await self.json_storage.upload_json(context.backup_name, manifest)
+        backup_name = self._make_backup_name(context)
+        logger.info("Storing backup manifest %s", backup_name)
+        await self.json_storage.upload_json(backup_name, manifest)
+
+    def _make_backup_name(self, context: StepsContext) -> str:
+        iso = context.attempt_start.isoformat(timespec="seconds")
+        return f"{magic.JSON_BACKUP_PREFIX}{iso}"
 
 
 @dataclasses.dataclass

--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -33,6 +33,9 @@ class CoordinatorPlugin(AstacusModel):
     def get_backup_steps(self, *, context: OperationContext) -> List[Step]:
         raise NotImplementedError
 
+    def get_delta_backup_steps(self, *, context: OperationContext) -> List[Step]:
+        raise NotImplementedError
+
     def get_restore_steps(self, *, context: OperationContext, req: ipc.RestoreRequest) -> List[Step]:
         raise NotImplementedError
 

--- a/astacus/coordinator/plugins/cassandra/plugin.py
+++ b/astacus/coordinator/plugins/cassandra/plugin.py
@@ -101,6 +101,9 @@ class CassandraPlugin(CoordinatorPlugin):
             ),
         ]
 
+    def get_delta_backup_steps(self, *, context: OperationContext) -> List[Step]:
+        raise NotImplementedError
+
     def get_restore_steps(self, *, context: OperationContext, req: ipc.RestoreRequest) -> List[Step]:
         nodes = self.nodes or [CassandraConfigurationNode(listen_address=self.client.get_listen_address())]
         cluster_restore_steps = (

--- a/astacus/coordinator/plugins/clickhouse/plugin.py
+++ b/astacus/coordinator/plugins/clickhouse/plugin.py
@@ -126,6 +126,9 @@ class ClickHousePlugin(CoordinatorPlugin):
             ),
         ]
 
+    def get_delta_backup_steps(self, *, context: OperationContext) -> List[Step]:
+        raise NotImplementedError
+
     def get_restore_steps(self, *, context: OperationContext, req: RestoreRequest) -> List[Step]:
         if req.partial_restore_nodes:
             # Required modifications to implement single-node restore:

--- a/astacus/coordinator/plugins/files.py
+++ b/astacus/coordinator/plugins/files.py
@@ -45,6 +45,9 @@ class FilesPlugin(CoordinatorPlugin):
             UploadManifestStep(json_storage=context.json_storage, plugin=Plugin.files),
         ]
 
+    def get_delta_backup_steps(self, *, context: OperationContext) -> List[Step]:
+        raise NotImplementedError
+
     def get_restore_steps(self, *, context: OperationContext, req: ipc.RestoreRequest) -> List[Step]:
         return [
             BackupNameStep(json_storage=context.json_storage, requested_name=req.name),

--- a/astacus/coordinator/plugins/flink/plugin.py
+++ b/astacus/coordinator/plugins/flink/plugin.py
@@ -46,6 +46,9 @@ class FlinkPlugin(CoordinatorPlugin):
             ),
         ]
 
+    def get_delta_backup_steps(self, *, context: OperationContext) -> List[Step]:
+        raise NotImplementedError
+
     def get_restore_steps(self, *, context: OperationContext, req: ipc.RestoreRequest) -> List[Step]:
         zookeeper_client = get_zookeeper_client(self.zookeeper)
         return [

--- a/astacus/coordinator/plugins/m3db.py
+++ b/astacus/coordinator/plugins/m3db.py
@@ -69,6 +69,9 @@ class M3DBPlugin(CoordinatorPlugin):
             ),
         ]
 
+    def get_delta_backup_steps(self, *, context: OperationContext) -> List[Step]:
+        raise NotImplementedError
+
     def get_restore_steps(self, *, context: OperationContext, req: ipc.RestoreRequest) -> List[Step]:
         etcd_client = ETCDClient(self.etcd_url)
         return [

--- a/astacus/node/clear.py
+++ b/astacus/node/clear.py
@@ -11,7 +11,6 @@ from .node import NodeOp
 from .snapshotter import Snapshotter
 from astacus.common import ipc
 from astacus.common.progress import Progress
-from astacus.common.snapshot import SnapshotGroup
 from typing import Optional
 
 import contextlib
@@ -22,15 +21,14 @@ logger = logging.getLogger(__name__)
 
 class ClearOp(NodeOp[ipc.SnapshotClearRequest, ipc.NodeResult]):
     snapshotter: Optional[Snapshotter] = None
+    is_snaphot_outdated: bool = True
 
     def create_result(self) -> ipc.NodeResult:
         return ipc.NodeResult()
 
-    def start(self) -> NodeOp.StartResult:
-        self.snapshotter = self.get_or_create_snapshotter(
-            [SnapshotGroup(root_glob=root_glob) for root_glob in self.req.root_globs]
-        )
+    def start(self, snapshotter: Snapshotter, *, is_snapshot_outdated: bool) -> NodeOp.StartResult:
         logger.info("start_clear %r", self.req)
+        self.snapshotter = snapshotter
         return self.start_op(op_name="clear", op=self, fun=self.clear)
 
     def clear(self) -> None:
@@ -38,7 +36,8 @@ class ClearOp(NodeOp[ipc.SnapshotClearRequest, ipc.NodeResult]):
         # 'snapshotter' is global; ensure we have sole access to it
         with self.snapshotter.lock:
             self.check_op_id()
-            self.snapshotter.snapshot(progress=Progress())
+            if self.is_snaphot_outdated:
+                self.snapshotter.snapshot(progress=Progress())
             files = set(self.snapshotter.relative_path_to_snapshotfile.keys())
             progress = self.result.progress
             progress.start(len(files))

--- a/astacus/node/config.py
+++ b/astacus/node/config.py
@@ -64,6 +64,9 @@ class NodeConfig(AstacusModel):
     # Directory is created if it does not exist
     root_link: Optional[Path]
 
+    # Same as root_link for the delta snapshotter.
+    delta_root_link: Optional[Path]
+
     # These can be either globally or locally set
     object_storage: Optional[RohmuConfig] = None
     statsd: Optional[StatsdConfig] = None

--- a/astacus/node/download.py
+++ b/astacus/node/download.py
@@ -14,7 +14,6 @@ from .snapshotter import Snapshotter
 from astacus.common import ipc, utils
 from astacus.common.progress import Progress
 from astacus.common.rohmustorage import RohmuStorage
-from astacus.common.snapshot import SnapshotGroup
 from astacus.common.storage import Storage, ThreadLocalStorage
 from astacus.common.utils import get_umask
 from pathlib import Path
@@ -165,11 +164,9 @@ class DownloadOp(NodeOp[ipc.SnapshotDownloadRequest, ipc.NodeResult]):
     def create_result(self) -> ipc.NodeResult:
         return ipc.NodeResult()
 
-    def start(self) -> NodeOp.StartResult:
-        self.snapshotter = self.get_or_create_snapshotter(
-            [SnapshotGroup(root_glob=root_glob) for root_glob in self.req.root_globs]
-        )
+    def start(self, snapshotter: Snapshotter) -> NodeOp.StartResult:
         logger.info("start_download %r", self.req)
+        self.snapshotter = snapshotter
         return self.start_op(op_name="download", op=self, fun=self.download)
 
     def download(self) -> None:

--- a/tests/unit/coordinator/plugins/test_base.py
+++ b/tests/unit/coordinator/plugins/test_base.py
@@ -68,6 +68,16 @@ def get_sample_hashes() -> list[ipc.SnapshotHash]:
     return [ipc.SnapshotHash(hexdigest=hexdigest, size=len(data))]
 
 
+@pytest.fixture(name="single_node_cluster")
+def fixture_single_node_cluster() -> Cluster:
+    return Cluster(nodes=[CoordinatorNode(url="http://node_1")])
+
+
+@pytest.fixture(name="context")
+def fixture_context() -> StepsContext:
+    return StepsContext()
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "node_features,expected_request",
@@ -86,17 +96,17 @@ def get_sample_hashes() -> list[ipc.SnapshotHash]:
     ids=["no_feature", "validate_file_hashes"],
 )
 async def test_upload_step_uses_new_request_if_supported(
-    node_features: Sequence[Features], expected_request: ipc.SnapshotUploadRequest
+    node_features: Sequence[Features],
+    expected_request: ipc.SnapshotUploadRequest,
+    single_node_cluster: Cluster,
+    context: StepsContext,
 ) -> None:
-    context = StepsContext()
     context.set_result(ListHexdigestsStep, {})
     sample_hashes = get_sample_hashes()
     context.set_result(
         SnapshotStep, [ipc.SnapshotResult(hostname="localhost", az="az1", files=1, total_size=2, hashes=sample_hashes)]
     )
     upload_step = UploadBlocksStep(storage_name="fake")
-    coordinator_nodes = [CoordinatorNode(url="http://node_1")]
-    cluster = Cluster(nodes=coordinator_nodes)
     with respx.mock:
 
         def check_request(request: httpx.Request) -> httpx.Response:
@@ -119,7 +129,61 @@ async def test_upload_step_uses_new_request_if_supported(
                 total_stored_size=8,
             ).jsondict()
         )
-        await upload_step.run_step(cluster=cluster, context=context)
+        await upload_step.run_step(cluster=single_node_cluster, context=context)
+
+
+BACKUPS_FOR_RETENTION_TEST = {
+    "b1": json.dumps(
+        {
+            "start": "2020-01-01T11:00Z",
+            "end": "2020-01-01T13:00Z",
+            "attempt": 1,
+            "snapshot_results": [],
+            "upload_results": [],
+            "plugin": "clickhouse",
+        }
+    ),
+    "b2": json.dumps(
+        {
+            "start": "2020-01-02T11:00Z",
+            "end": "2020-01-02T13:00Z",
+            "attempt": 1,
+            "snapshot_results": [],
+            "upload_results": [],
+            "plugin": "clickhouse",
+        }
+    ),
+    "b3": json.dumps(
+        {
+            "start": "2020-01-03T11:00Z",
+            "end": "2020-01-03T13:00Z",
+            "attempt": 1,
+            "snapshot_results": [],
+            "upload_results": [],
+            "plugin": "clickhouse",
+        }
+    ),
+    "b4": json.dumps(
+        {
+            "start": "2020-01-04T11:00Z",
+            "end": "2020-01-04T13:00Z",
+            "attempt": 1,
+            "snapshot_results": [],
+            "upload_results": [],
+            "plugin": "clickhouse",
+        }
+    ),
+    "b5": json.dumps(
+        {
+            "start": "2020-01-05T11:00Z",
+            "end": "2020-01-05T13:00Z",
+            "attempt": 1,
+            "snapshot_results": [],
+            "upload_results": [],
+            "plugin": "clickhouse",
+        }
+    ),
+}
 
 
 @pytest.mark.asyncio
@@ -134,72 +198,20 @@ async def test_upload_step_uses_new_request_if_supported(
         (ipc.Retention(minimum_backups=0, maximum_backups=3, keep_days=0), set()),
     ],
 )
-async def test_compute_kept_backups(retention: ipc.Retention, kept_backups: AbstractSet[str]) -> None:
-    async_json_storage = AsyncJsonStorage(
-        storage=MemoryJsonStorage(
-            items={
-                "b1": json.dumps(
-                    {
-                        "start": "2020-01-01T11:00Z",
-                        "end": "2020-01-01T13:00Z",
-                        "attempt": 1,
-                        "snapshot_results": [],
-                        "upload_results": [],
-                        "plugin": "clickhouse",
-                    }
-                ),
-                "b2": json.dumps(
-                    {
-                        "start": "2020-01-02T11:00Z",
-                        "end": "2020-01-02T13:00Z",
-                        "attempt": 1,
-                        "snapshot_results": [],
-                        "upload_results": [],
-                        "plugin": "clickhouse",
-                    }
-                ),
-                "b3": json.dumps(
-                    {
-                        "start": "2020-01-03T11:00Z",
-                        "end": "2020-01-03T13:00Z",
-                        "attempt": 1,
-                        "snapshot_results": [],
-                        "upload_results": [],
-                        "plugin": "clickhouse",
-                    }
-                ),
-                "b4": json.dumps(
-                    {
-                        "start": "2020-01-04T11:00Z",
-                        "end": "2020-01-04T13:00Z",
-                        "attempt": 1,
-                        "snapshot_results": [],
-                        "upload_results": [],
-                        "plugin": "clickhouse",
-                    }
-                ),
-                "b5": json.dumps(
-                    {
-                        "start": "2020-01-05T11:00Z",
-                        "end": "2020-01-05T13:00Z",
-                        "attempt": 1,
-                        "snapshot_results": [],
-                        "upload_results": [],
-                        "plugin": "clickhouse",
-                    }
-                ),
-            }
-        )
-    )
+async def test_compute_kept_backups(
+    retention: ipc.Retention,
+    kept_backups: AbstractSet[str],
+    single_node_cluster: Cluster,
+    context: StepsContext,
+) -> None:
+    async_json_storage = AsyncJsonStorage(storage=MemoryJsonStorage(items=BACKUPS_FOR_RETENTION_TEST))
     step = ComputeKeptBackupsStep(
         json_storage=async_json_storage,
         retention=retention,
         explicit_delete=[],
     )
-    cluster = Cluster(nodes=[CoordinatorNode(url="http://node_1")])
-    context = StepsContext()
     context.set_result(ListBackupsStep, set(await async_json_storage.list_jsons()))
     half_a_day_after_last_backup = datetime.datetime(2020, 1, 7, 5, 0, tzinfo=datetime.timezone.utc)
     with mock.patch.object(utils, "now", lambda: half_a_day_after_last_backup):
-        result = await step.run_step(cluster=cluster, context=context)
+        result = await step.run_step(cluster=single_node_cluster, context=context)
     assert result == kept_backups


### PR DESCRIPTION
Add the concept of a lighter "delta" backup to Astacus. Lighter "delta" backups contain only the data reported as such by the database itself (e.g. via commit logs or Cassandra incremental backups). Compared to the "regular" snapshot-based backups, delta backups:
* do not require listing the hexdigest storage to create the backup
* do not require to build a full list of files present in the database to determine the diff
* can be restored one on top of the other (during node replacement this allows to do "catch-up" on the replacement before draining&removing the old node, decreasing the window of time the cluster is running with RF-1 nodes)

The delta APIs re-use the download and snapshot methods already present, but:
* deltas are gathered and uploaded using a different Snapshotter instance targeted at the delta globs
* Cassandra incremental backups require the user to remove the incremental files once the user's done with them, so an additional Clear step is added at the end

This PR is also an invitation to a discussion: do we need a separate "delta backup" concept in Astacus? My main "pro" arguments are:
* enables the "catch-up" behavior during replacement
* looks more natural in a PITR context (technically one could increase backup frequency to "each 5 minutes" and include the commitlogs since the latest full backup to allow restoring to "somewhere in between", but that looks a bit counterintuitive: why would a snapshot include something that depends on a previous snapshot?)
* doesn't require to iterate through all the files (and hexdigests) every time we want to do a backup (might not be compelling enough on it's own, but it's a nice bonus)