### PR TITLE
common: stream uploaded files

### DIFF
--- a/astacus/common/storage.py
+++ b/astacus/common/storage.py
@@ -57,15 +57,11 @@ class HexDigestStorage(ABC):
         ...
 
     def upload_hexdigest_bytes(self, hexdigest: str, data: bytes) -> StorageUploadResult:
-        return self.upload_hexdigest_from_file(hexdigest, io.BytesIO(data))
+        return self.upload_hexdigest_from_file(hexdigest, io.BytesIO(data), len(data))
 
     @abstractmethod
-    def upload_hexdigest_from_file(self, hexdigest: str, f: BinaryIO) -> StorageUploadResult:
+    def upload_hexdigest_from_file(self, hexdigest: str, f: BinaryIO, file_size: int) -> StorageUploadResult:
         ...
-
-    def upload_hexdigest_from_path(self, hexdigest: str, filename: str | Path) -> StorageUploadResult:
-        with open(filename, "rb") as f:
-            return self.upload_hexdigest_from_file(hexdigest, f)
 
 
 class JsonStorage(ABC):
@@ -152,7 +148,7 @@ class FileStorage(Storage):
         f.write(path.read_bytes())
         return True
 
-    def upload_hexdigest_from_file(self, hexdigest: str, f: BinaryIO) -> StorageUploadResult:
+    def upload_hexdigest_from_file(self, hexdigest: str, f: BinaryIO, file_size: int) -> StorageUploadResult:
         logger.info("upload_hexdigest_from_file %r", hexdigest)
         path = self._hexdigest_to_path(hexdigest)
         data = f.read()

--- a/astacus/node/uploader.py
+++ b/astacus/node/uploader.py
@@ -48,7 +48,7 @@ class Uploader(ThreadLocalStorage):
                         continue
                 try:
                     with snapshotfile.open_for_reading(snapshotter.dst) as f:
-                        upload_result = storage.upload_hexdigest_from_file(hexdigest, f)
+                        upload_result = storage.upload_hexdigest_from_file(hexdigest, f, file_size=snapshotfile.file_size)
                 except exceptions.TransientException as ex:
                     # Do not pollute logs with transient exceptions
                     logger.info("Transient exception uploading %r: %r", path, ex)


### PR DESCRIPTION
Instead of encrypting and compressing the entire file on disk and then uploading that.
Progressively compress, encrypt and upload at the same time.

This reduces the Disk IO load during backups and avoid filling the disk if there is not enough
space left and individual files are large (such as Cassandra SSTable or ClickHouse part files).

[DDB-543]