### PR TITLE
Log only the error when connecting to Cassandra

### DIFF
--- a/astacus/common/cassandra/client.py
+++ b/astacus/common/cassandra/client.py
@@ -90,7 +90,7 @@ class CassandraClient:
 
             error = error_values[0]
 
-            logger.exception("Unexpected exception while connecting to local cassandra: %r", error)
+            logger.error("Unexpected exception while connecting to local cassandra: %r", error)
             raise NoHostAvailableException from ex
 
     async def run_sync(self, fun: Callable, *args: Any, **kwargs: Any) -> Any:


### PR DESCRIPTION
Logging full stack trace when we fail to connect to the local Cassandra instance seems overkill, because it's a transient error -> it's retried and the stack traces clutter the log. Also is picked up by Sentry SDK, which is unnecessary since the exception is expected.