### PR TITLE
Make sstable restoration configurable

### DIFF
--- a/astacus/common/cassandra/config.py
+++ b/astacus/common/cassandra/config.py
@@ -24,6 +24,7 @@ from typing import List, Optional
 import yaml
 
 SNAPSHOT_NAME = "astacus-backup"
+SNAPSHOT_GLOB = f"data/*/*/snapshots/{SNAPSHOT_NAME}"
 
 
 class CassandraClientConfiguration(AstacusModel):

--- a/astacus/common/cassandra/utils.py
+++ b/astacus/common/cassandra/utils.py
@@ -6,14 +6,14 @@ Miscellaneous utilities related to CassandraSession
 
 """
 
-_SYSTEM_KEYSPACES = {
+SYSTEM_KEYSPACES = [
     "system",
     # "system_auth", # While technically system keyspace, we want to restore this
     "system_distributed",
     "system_schema",
     "system_traces",
-}
+]
 
 
 def is_system_keyspace(keyspace: str) -> bool:
-    return keyspace in _SYSTEM_KEYSPACES
+    return keyspace in SYSTEM_KEYSPACES

--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -195,9 +195,8 @@ class SnapshotClearRequest(NodeRequest):
 class CassandraSubOp(StrEnum):
     get_schema_hash = "get-schema-hash"
     remove_snapshot = "remove-snapshot"
-    unrestore_snapshot = "unrestore-snapshot"
-    restore_snapshot = "restore-snapshot"
-    restore_snapshot_with_schema = "restore-snapshot-with-schema"
+    unrestore_sstables = "unrestore-sstables"
+    restore_sstables = "restore-sstables"
     start_cassandra = "start-cassandra"
     stop_cassandra = "stop-cassandra"
     take_snapshot = "take-snapshot"
@@ -211,6 +210,17 @@ class CassandraStartRequest(NodeRequest):
 
 class CassandraGetSchemaHashResult(NodeResult):
     schema_hash: str
+
+
+class CassandraTableMatching(StrEnum):
+    cfid = "cfid"
+    cfname = "cfname"
+
+
+class CassandraRestoreSSTablesRequest(NodeRequest):
+    table_glob: str
+    keyspaces_to_skip: Sequence[str]
+    match_tables_by: CassandraTableMatching
 
 
 # coordinator.api

--- a/astacus/node/cassandra.py
+++ b/astacus/node/cassandra.py
@@ -10,8 +10,7 @@ Cassandra handling that is run on every node in the Cluster
 from .node import NodeOp
 from astacus.common import ipc
 from astacus.common.cassandra.client import CassandraClient
-from astacus.common.cassandra.config import SNAPSHOT_NAME
-from astacus.common.cassandra.utils import is_system_keyspace
+from astacus.common.cassandra.config import SNAPSHOT_GLOB, SNAPSHOT_NAME
 from astacus.common.exceptions import TransientException
 from pathlib import Path
 from pydantic import DirectoryPath
@@ -26,7 +25,6 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
-SNAPSHOT_GLOB = f"data/*/*/snapshots/{SNAPSHOT_NAME}"
 TABLES_GLOB = "data/*/*"
 
 
@@ -48,9 +46,7 @@ class SimpleCassandraSubOp(NodeOp[ipc.NodeRequest, ipc.NodeResult]):
             op=self,
             fun={
                 ipc.CassandraSubOp.remove_snapshot: self.remove_snapshot,
-                ipc.CassandraSubOp.unrestore_snapshot: self.unrestore_snapshot,
-                ipc.CassandraSubOp.restore_snapshot: self.restore_snapshot,
-                ipc.CassandraSubOp.restore_snapshot_with_schema: self.restore_snapshot_with_schema,
+                ipc.CassandraSubOp.unrestore_sstables: self.unrestore_sstables,
                 ipc.CassandraSubOp.stop_cassandra: self.stop_cassandra,
                 ipc.CassandraSubOp.take_snapshot: self.take_snapshot,
             }[subop],
@@ -67,7 +63,7 @@ class SimpleCassandraSubOp(NodeOp[ipc.NodeRequest, ipc.NodeResult]):
         """
         self._clean_matching(SNAPSHOT_GLOB, clean_func=shutil.rmtree)
 
-    def unrestore_snapshot(self) -> None:
+    def unrestore_sstables(self) -> None:
         """Remove everything from the data dir except the snapshots and backups.
 
         This is the "opposite" of restore snapshot subop: it cleans all the live
@@ -109,34 +105,43 @@ class SimpleCassandraSubOp(NodeOp[ipc.NodeRequest, ipc.NodeResult]):
             else:
                 p.unlink(missing_ok=True)
 
-    def restore_snapshot(self) -> None:
-        self._restore_snapshot(is_schema_restored=False)
+    def stop_cassandra(self) -> None:
+        assert self.config.cassandra
+        subprocess.run(self.config.cassandra.stop_command, check=True)
+        self.result.progress.done()
 
-    def restore_snapshot_with_schema(self) -> None:
-        self._restore_snapshot(is_schema_restored=True)
+    def take_snapshot(self) -> None:
+        assert self.config.cassandra
+        cmd = self.config.cassandra.nodetool_command[:]
+        cmd.extend(["snapshot", "-t", SNAPSHOT_NAME])
+        subprocess.run(cmd, check=True)
+        self.result.progress.done()
 
-    def _restore_snapshot(self, *, is_schema_restored: bool) -> None:
+
+class CassandraRestoreSSTablesOp(NodeOp[ipc.CassandraRestoreSSTablesRequest, ipc.NodeResult]):
+    def create_result(self) -> ipc.NodeResult:
+        return ipc.NodeResult()
+
+    def start(self) -> NodeOp.StartResult:
+        return self.start_op(op_name="cassandra", op=self, fun=self.restore_sstables)
+
+    def restore_sstables(self) -> None:
         """This is used to restore the snapshot files into place, with Cassandra offline."""
-        # TBD: Delete extra data (current cashew doesn't do it, but we could)
-
         # Move files from Astacus snapshot directories to the actual data directories
         progress = self.result.progress
-        table_snapshots = list(self.config.root.glob(SNAPSHOT_GLOB))
+        table_snapshots = list(self.config.root.glob(self.req.table_glob))
         progress.add_total(len(table_snapshots))
 
         for table_snapshot in table_snapshots:
             # expected table_snapshot structure: <config.root>/data/ks/tname-tid/...
             keyspace_name, table_name_and_id = table_snapshot.relative_to(self.config.root / "data").parts[:2]
-            skip_system_keyspace = is_system_keyspace(keyspace_name)
-            if is_schema_restored:
-                skip_system_keyspace = is_system_keyspace(keyspace_name) and keyspace_name != "system_schema"
-            if skip_system_keyspace:
+            if keyspace_name in self.req.keyspaces_to_skip:
                 progress.add_success()
                 continue
 
             table_path = (
                 self.config.root / "data" / keyspace_name / table_name_and_id
-                if is_schema_restored
+                if self.req.match_tables_by == ipc.CassandraTableMatching.cfid
                 else self._match_table_by_name(keyspace_name, table_name_and_id)
             )
 
@@ -169,18 +174,6 @@ class SimpleCassandraSubOp(NodeOp[ipc.NodeRequest, ipc.NodeResult]):
         assert len(table_paths) == 1
 
         return table_paths[0]
-
-    def stop_cassandra(self) -> None:
-        assert self.config.cassandra
-        subprocess.run(self.config.cassandra.stop_command, check=True)
-        self.result.progress.done()
-
-    def take_snapshot(self) -> None:
-        assert self.config.cassandra
-        cmd = self.config.cassandra.nodetool_command[:]
-        cmd.extend(["snapshot", "-t", SNAPSHOT_NAME])
-        subprocess.run(cmd, check=True)
-        self.result.progress.done()
 
 
 class CassandraStartOp(NodeOp[ipc.CassandraStartRequest, ipc.NodeResult]):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -49,6 +49,10 @@ class CassandraTestConfig:
         self.snapshot_path = keyspace_path / "dummytable-123" / "snapshots" / SNAPSHOT_NAME
         self.snapshot_path.mkdir(parents=True)
 
+        other_table_path = keyspace_path / "anothertable-345" / "snapshots" / SNAPSHOT_NAME
+        other_table_path.mkdir(parents=True)
+        (other_table_path / "data.file").write_text("data")
+
         system_schema_path = self.root / "data" / "system_schema" / "tables-789" / "snapshots" / SNAPSHOT_NAME
         system_schema_path.mkdir(parents=True)
         (system_schema_path / "data.file").write_text("schema")
@@ -65,6 +69,7 @@ listen_address: 127.0.0.1
 
         (self.snapshot_path / "asdf").write_text("foobar")
         (keyspace_path / "dummytable-234").mkdir()
+        (keyspace_path / "anothertable-789").mkdir()
 
         named_temporary_file = mocker.patch.object(tempfile, "NamedTemporaryFile")
         self.fake_conffile = StringIO()


### PR DESCRIPTION
Instead of hard-coding sstable restoration glob and matching strategy, make it configurable from coordinator side. Allows to keep the subop enum small while allowing to add incremental backup restoration.
    
Presently we use 2 configurations:
* restore without system_schema, match tables by name
* restore with system_schema, match tables by id

Incremental backup restoration needs both these options, but with a different table glob (from /backups instead of /snapshots/astacus).