### PR TITLE
Support addressing_style for rohmu s3 configurations

### DIFF
--- a/astacus/common/rohmustorage.py
+++ b/astacus/common/rohmustorage.py
@@ -100,6 +100,7 @@ class RohmuS3StorageConfig(RohmuProxyStorage):
     is_secure: Optional[bool] = False
     is_verify_tls: Optional[bool] = False
     prefix: Optional[str] = None
+    addressing_style: Optional[str] = None
     # Some more obscure options with defaults are omitted
 
 


### PR DESCRIPTION
Support addressing_style for rohmu s3 configurations:  this can be useful to support S3-compatible object storage that requires to use the (deprecated?) path style addressing.