### PR TITLE
Release extra files in dst after upload

### DIFF
--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -189,6 +189,11 @@ class SnapshotClearRequest(NodeRequest):
     root_globs: Sequence[str]
 
 
+class SnapshotReleaseRequest(NodeRequest):
+    # Files matching these digests will be unlinked in snapshotter's dst
+    hexdigests: Sequence[str]
+
+
 # node.cassandra
 
 

--- a/astacus/coordinator/cluster.py
+++ b/astacus/coordinator/cluster.py
@@ -67,8 +67,8 @@ class Cluster:
         *,
         caller: str,
         req: Optional[ipc.NodeRequest] = None,
-        reqs: Optional[List[ipc.NodeRequest]] = None,
-        nodes: Optional[List[CoordinatorNode]] = None,
+        reqs: Optional[Sequence[ipc.NodeRequest]] = None,
+        nodes: Optional[Sequence[CoordinatorNode]] = None,
         **kw,
     ) -> Sequence[Optional[Result]]:
         """Perform asynchronously parallel request to the node components.

--- a/astacus/coordinator/plugins/cassandra/plugin.py
+++ b/astacus/coordinator/plugins/cassandra/plugin.py
@@ -98,6 +98,7 @@ class CassandraPlugin(CoordinatorPlugin):
             base.ListHexdigestsStep(hexdigest_storage=context.hexdigest_storage),
             base.UploadBlocksStep(storage_name=context.storage_name),
             CassandraSubOpStep(op=ipc.CassandraSubOp.remove_snapshot),
+            base.SnapshotReleaseStep(),
             base.UploadManifestStep(
                 json_storage=context.json_storage,
                 plugin=ipc.Plugin.cassandra,

--- a/astacus/node/snapshotter.py
+++ b/astacus/node/snapshotter.py
@@ -113,6 +113,10 @@ class Snapshotter:
         if snapshotfile.hexdigest:
             self.hexdigest_to_snapshotfiles[snapshotfile.hexdigest].remove(snapshotfile)
 
+    def _release_snapshotfile(self, snapshotfile: SnapshotFile) -> None:
+        dst_path = self.dst / snapshotfile.relative_path
+        dst_path.unlink(missing_ok=True)
+
     def _snapshotfile_from_path(self, relative_path) -> SnapshotFile:
         src_path = self.src / relative_path
         st = src_path.stat()
@@ -273,3 +277,9 @@ class Snapshotter:
         progress.add_success()
 
         return changes
+
+    def release(self, hexdigest: str) -> None:
+        assert self.lock.locked()
+        assert self.src != self.dst
+        for snapshotfile in self.hexdigest_to_snapshotfiles.get(hexdigest, []):
+            self._release_snapshotfile(snapshotfile)

--- a/tests/unit/node/test_snapshotter.py
+++ b/tests/unit/node/test_snapshotter.py
@@ -4,7 +4,7 @@ See LICENSE for details
 """
 from astacus.common.progress import Progress
 from astacus.common.snapshot import SnapshotGroup
-from astacus.node.snapshotter import Snapshotter
+from astacus.node.snapshotter import hash_hexdigest_readable, Snapshotter
 from pathlib import Path
 
 
@@ -21,3 +21,44 @@ def test_snapshotter_with_src_equal_dst_forgets_file_from_previous_snapshot(tmp_
         file_after.write_bytes(b"y" * 1024)
         snapshotter.snapshot(progress=Progress())
         assert snapshotter.relative_path_to_snapshotfile.keys() == {Path("file_after")}
+
+
+def assert_kept(hexdigest: str, dst_path: Path, snapshotter: Snapshotter):
+    assert dst_path.exists()
+    assert hexdigest in snapshotter.hexdigest_to_snapshotfiles
+    assert Path(dst_path.name) in snapshotter.relative_path_to_snapshotfile
+
+
+def assert_released(hexdigest: str, dst_path: Path, snapshotter: Snapshotter):
+    assert not dst_path.exists()
+    assert hexdigest in snapshotter.hexdigest_to_snapshotfiles
+    assert Path(dst_path.name) in snapshotter.relative_path_to_snapshotfile
+
+
+def test_snapshotter_release_hash_unlinks_files_but_keeps_metadata(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    dst.mkdir()
+    (src / "keep_this").write_text("this will be kept")
+    kept_digest = hash_hexdigest_readable((src / "keep_this").open(mode="rb"))
+    (src / "release_this").write_text("this will be released")
+    released_digest = hash_hexdigest_readable((src / "release_this").open(mode="rb"))
+    snapshotter = Snapshotter(src=src, dst=dst, groups=[SnapshotGroup(root_glob="*", embedded_file_size_max=0)], parallel=1)
+
+    with snapshotter.lock:
+        snapshotter.snapshot(progress=Progress())
+        assert_kept(kept_digest, dst / "keep_this", snapshotter)
+        assert_kept(released_digest, dst / "release_this", snapshotter)
+
+        snapshotter.release(released_digest)
+        assert_kept(kept_digest, dst / "keep_this", snapshotter)
+        assert_released(released_digest, dst / "release_this", snapshotter)
+
+        # re-snapshotting should restore the link
+        (src / "add_this").write_text("this is added for the next snapshot")
+        added_digest = hash_hexdigest_readable((src / "add_this").open(mode="rb"))
+        snapshotter.snapshot(progress=Progress())
+        assert_kept(kept_digest, dst / "keep_this", snapshotter)
+        assert_kept(released_digest, dst / "release_this", snapshotter)
+        assert_kept(added_digest, dst / "add_this", snapshotter)


### PR DESCRIPTION
Allow the coordinator to release the files that were uploaded during backup creation. Helps to free disk space after the backup was uploaded. Especially useful for Cassandra, since because of compactions we end up keeping around copies of old sstables.