### PR TITLE
Restore delta backups in Cassandra

### DIFF
--- a/astacus/common/cassandra/config.py
+++ b/astacus/common/cassandra/config.py
@@ -25,6 +25,7 @@ import yaml
 
 SNAPSHOT_NAME = "astacus-backup"
 SNAPSHOT_GLOB = f"data/*/*/snapshots/{SNAPSHOT_NAME}"
+BACKUP_GLOB = "data/*/*/backups/"
 
 
 class CassandraClientConfiguration(AstacusModel):

--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -257,6 +257,7 @@ class CassandraRestoreSSTablesRequest(NodeRequest):
     table_glob: str
     keyspaces_to_skip: Sequence[str]
     match_tables_by: CassandraTableMatching
+    expect_empty_target: bool
 
 
 # coordinator.api

--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -9,11 +9,12 @@ See LICENSE for details
 from .magic import DEFAULT_EMBEDDED_FILE_SIZE, StrEnum
 from .progress import Progress
 from .utils import AstacusModel, now, SizeLimitedFile
+from astacus.common.snapshot import SnapshotGroup
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from pydantic import Field, root_validator
-from typing import List, Optional, Sequence
+from typing import List, Optional, Sequence, Set
 
 import functools
 import socket
@@ -116,6 +117,26 @@ class SnapshotRequestV2(NodeRequest):
     groups: Sequence[SnapshotRequestGroup] = ()
     # Accept V1 request for backward compatibility if the controller is older
     root_globs: Sequence[str] = ()
+
+
+def create_snapshot_request(
+    snapshot_groups: Sequence[SnapshotGroup], *, node_features: Set[str]
+) -> SnapshotRequestV2 | SnapshotRequest:
+    if NodeFeatures.snapshot_groups.value in node_features:
+        return SnapshotRequestV2(
+            groups=[
+                SnapshotRequestGroup(
+                    root_glob=group.root_glob,
+                    excluded_names=group.excluded_names,
+                    embedded_file_size_max=group.embedded_file_size_max,
+                )
+                for group in snapshot_groups
+            ],
+        )
+    # This is a lossy backward compatibility since the extra options are not passed
+    return SnapshotRequest(
+        root_globs=[group.root_glob for group in snapshot_groups],
+    )
 
 
 class SnapshotHash(AstacusModel):

--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -10,6 +10,7 @@ from .magic import DEFAULT_EMBEDDED_FILE_SIZE, StrEnum
 from .progress import Progress
 from .utils import AstacusModel, now, SizeLimitedFile
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
 from pydantic import Field, root_validator
 from typing import List, Optional, Sequence
@@ -26,6 +27,15 @@ class Plugin(StrEnum):
     files = "files"
     m3db = "m3db"
     flink = "flink"
+
+
+class NodeFeatures(Enum):
+    # Added on 2022-11-29, this can be assumed to be supported everywhere after 1 or 2 years
+    validate_file_hashes = "validate_file_hashes"
+    # Added on 2023-06-07
+    snapshot_groups = "snapshot_groups"
+    # Added on 2023-10-16
+    release_snapshot_files = "release_snapshot_files"
 
 
 class Retention(AstacusModel):

--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -15,7 +15,6 @@ from astacus.common.utils import AstacusModel
 from astacus.coordinator.cluster import Cluster, Result
 from astacus.coordinator.config import CoordinatorNode
 from astacus.coordinator.manifest import download_backup_manifest
-from astacus.node.api import Features
 from collections import Counter
 from typing import Any, Counter as TCounter, Dict, Generic, List, Optional, Sequence, Set, Type, TypeVar
 
@@ -101,7 +100,7 @@ class SnapshotStep(Step[List[ipc.SnapshotResult]]):
 
     async def run_step(self, cluster: Cluster, context: StepsContext) -> List[ipc.SnapshotResult]:
         nodes_metadata = await get_nodes_metadata(cluster)
-        if all(Features.snapshot_groups.value in node_metadata.features for node_metadata in nodes_metadata):
+        if all(ipc.NodeFeatures.snapshot_groups.value in node_metadata.features for node_metadata in nodes_metadata):
             req: ipc.NodeRequest = ipc.SnapshotRequestV2(
                 groups=[
                     ipc.SnapshotRequestGroup(
@@ -203,7 +202,7 @@ class SnapshotReleaseStep(Step[List[ipc.NodeResult]]):
         snapshot_results = context.get_result(SnapshotStep)
         nodes_metadata = await get_nodes_metadata(cluster)
         all_nodes_have_release_feature = nodes_metadata and all(
-            Features.release_snapshot_files.value in n.features for n in nodes_metadata
+            ipc.NodeFeatures.release_snapshot_files.value in n.features for n in nodes_metadata
         )
         if not all_nodes_have_release_feature:
             logger.info("Skipped SnapshotReleaseStep because some nodes don't support it, node features: %s", nodes_metadata)
@@ -635,7 +634,7 @@ async def upload_node_index_datas(
     start_results: List[Optional[Result]] = []
     nodes_metadata = await get_nodes_metadata(cluster)
     for data in node_index_datas:
-        if Features.validate_file_hashes.value in nodes_metadata[data.node_index].features:
+        if ipc.NodeFeatures.validate_file_hashes.value in nodes_metadata[data.node_index].features:
             req: ipc.NodeRequest = ipc.SnapshotUploadRequestV20221129(
                 hashes=data.sshashes, storage=storage_name, validate_file_hashes=validate_file_hashes
             )

--- a/astacus/coordinator/plugins/cassandra/plugin.py
+++ b/astacus/coordinator/plugins/cassandra/plugin.py
@@ -151,12 +151,25 @@ class CassandraPlugin(CoordinatorPlugin):
             table_glob=SNAPSHOT_GLOB,
             keyspaces_to_skip=[ks for ks in SYSTEM_KEYSPACES if ks != "system_schema"],
             match_tables_by=ipc.CassandraTableMatching.cfid,
+            expect_empty_target=True,
         )
 
         return [
             base.RestoreStep(storage_name=context.storage_name, partial_restore_nodes=req.partial_restore_nodes),
             CassandraRestoreSubOpStep(op=ipc.CassandraSubOp.restore_sstables, req=restore_sstables_req),
+            base.DeltaManifestsStep(json_storage=context.json_storage),
+            restore_steps.RestoreCassandraDeltasStep(
+                json_storage=context.json_storage,
+                storage_name=context.storage_name,
+                partial_restore_nodes=req.partial_restore_nodes,
+            ),
             restore_steps.StopReplacedNodesStep(partial_restore_nodes=req.partial_restore_nodes, cassandra_nodes=self.nodes),
+            restore_steps.UploadFinalDeltaStep(json_storage=context.json_storage, storage_name=context.storage_name),
+            restore_steps.RestoreFinalDeltasStep(
+                json_storage=context.json_storage,
+                storage_name=context.storage_name,
+                partial_restore_nodes=req.partial_restore_nodes,
+            ),
             restore_steps.StartCassandraStep(replace_backup_nodes=True, override_tokens=True, cassandra_nodes=self.nodes),
             restore_steps.WaitCassandraUpStep(duration=self.restore_start_timeout),
         ]
@@ -168,6 +181,7 @@ class CassandraPlugin(CoordinatorPlugin):
             table_glob=SNAPSHOT_GLOB,
             keyspaces_to_skip=SYSTEM_KEYSPACES,
             match_tables_by=ipc.CassandraTableMatching.cfname,
+            expect_empty_target=True,
         )
         return [
             # Start cassandra with backed up token distribution + set schema + stop it
@@ -175,7 +189,10 @@ class CassandraPlugin(CoordinatorPlugin):
             restore_steps.WaitCassandraUpStep(duration=self.restore_start_timeout),
             restore_steps.RestorePreDataStep(client=client),
             CassandraRestoreSubOpStep(op=ipc.CassandraSubOp.stop_cassandra),
-            # Restore snapshot
+            # Restore snapshot. Restoring deltas is not possible in this scenario,
+            # because once we've created our own system_schema keyspace and written data to it,
+            # we've started a new sequence of sstables that might clash with the sequence from the node
+            # we took the backup from (e.g. the old node had nb-1, the new node has nb-1, unclear how to proceed).
             base.RestoreStep(storage_name=context.storage_name, partial_restore_nodes=req.partial_restore_nodes),
             CassandraRestoreSubOpStep(op=ipc.CassandraSubOp.restore_sstables, req=restore_sstables_req),
             # restart cassandra and do the final actions with data available

--- a/astacus/coordinator/plugins/cassandra/plugin.py
+++ b/astacus/coordinator/plugins/cassandra/plugin.py
@@ -85,6 +85,7 @@ class CassandraPlugin(CoordinatorPlugin):
         snapshot_groups = [
             SnapshotGroup(root_glob=f"data/*/*/snapshots/{SNAPSHOT_NAME}/*.db"),
             SnapshotGroup(root_glob=f"data/*/*/snapshots/{SNAPSHOT_NAME}/*.txt"),
+            SnapshotGroup(root_glob=f"data/*/*/snapshots/{SNAPSHOT_NAME}/*.crc32"),
         ]
 
         return [
@@ -112,6 +113,7 @@ class CassandraPlugin(CoordinatorPlugin):
         delta_snapshot_groups = [
             SnapshotGroup(root_glob="data/*/*/backups/*.db"),
             SnapshotGroup(root_glob="data/*/*/backups/*.txt"),
+            SnapshotGroup(root_glob="data/*/*/backups/*.crc32"),
         ]
 
         @dataclasses.dataclass

--- a/astacus/coordinator/plugins/cassandra/utils.py
+++ b/astacus/coordinator/plugins/cassandra/utils.py
@@ -7,6 +7,8 @@ cassandra backup/restore plugin utilities
 
 
 from astacus.common import ipc
+from astacus.common.cassandra.config import SNAPSHOT_NAME
+from astacus.common.snapshot import SnapshotGroup
 from astacus.coordinator.cluster import Cluster
 from astacus.coordinator.config import CoordinatorNode
 from astacus.coordinator.plugins.base import StepFailedError
@@ -49,3 +51,21 @@ async def get_schema_hash(cluster: Cluster) -> Tuple[str, str]:
     if len(set(hashes)) != 1:
         return "", f"Multiple schema hashes present: {hashes}"
     return hashes[0], ""
+
+
+def snapshot_groups() -> List[SnapshotGroup]:
+    # first *: keyspace name; second *: table name
+    return [
+        SnapshotGroup(root_glob=f"data/*/*/snapshots/{SNAPSHOT_NAME}/*.db"),
+        SnapshotGroup(root_glob=f"data/*/*/snapshots/{SNAPSHOT_NAME}/*.txt"),
+        SnapshotGroup(root_glob=f"data/*/*/snapshots/{SNAPSHOT_NAME}/*.crc32"),
+    ]
+
+
+def delta_snapshot_groups() -> List[SnapshotGroup]:
+    # first *: keyspace name; second *: table name
+    return [
+        SnapshotGroup(root_glob="data/*/*/backups/*.db"),
+        SnapshotGroup(root_glob="data/*/*/backups/*.txt"),
+        SnapshotGroup(root_glob="data/*/*/backups/*.crc32"),
+    ]

--- a/astacus/node/api.py
+++ b/astacus/node/api.py
@@ -171,6 +171,20 @@ def download_result(*, op_id: int, n: Node = Depends()):
     return op.result
 
 
+@router.post("/delta/download")
+def delta_download(req: ipc.SnapshotDownloadRequest, n: Node = Depends()):
+    if not n.state.is_locked:
+        raise HTTPException(status_code=409, detail="Not locked")
+    snapshotter = delta_snapshotter_from_snapshot_req(req, n)
+    return DownloadOp(n=n, op_id=n.allocate_op_id(), stats=n.stats, req=req).start(snapshotter)
+
+
+@router.get("/delta/download/{op_id}")
+def delta_download_result(*, op_id: int, n: Node = Depends()):
+    op, _ = n.get_op_and_op_info(op_id=op_id, op_name=OpName.download)
+    return op.result
+
+
 @router.post("/clear")
 def clear(req: ipc.SnapshotClearRequest, n: Node = Depends()):
     if not n.state.is_locked:

--- a/astacus/node/api.py
+++ b/astacus/node/api.py
@@ -14,7 +14,6 @@ from astacus.common.snapshot import SnapshotGroup
 from astacus.node.config import CassandraAccessLevel
 from astacus.node.snapshotter import Snapshotter
 from astacus.version import __version__
-from enum import Enum
 from fastapi import APIRouter, Depends, HTTPException
 from typing import Sequence, Union
 
@@ -38,15 +37,6 @@ class OpName(StrEnum):
     release = "release"
 
 
-class Features(Enum):
-    # Added on 2022-11-29, this can be assumed to be supported everywhere after 1 or 2 years
-    validate_file_hashes = "validate_file_hashes"
-    # Added on 2023-06-07
-    snapshot_groups = "snapshot_groups"
-    # Added on 2023-10-16
-    release_snapshot_files = "release_snapshot_files"
-
-
 def is_allowed(subop: ipc.CassandraSubOp, access_level: CassandraAccessLevel):
     match access_level:
         case CassandraAccessLevel.read:
@@ -59,7 +49,7 @@ def is_allowed(subop: ipc.CassandraSubOp, access_level: CassandraAccessLevel):
 def metadata() -> ipc.MetadataResult:
     return ipc.MetadataResult(
         version=__version__,
-        features=[feature.value for feature in Features],
+        features=[feature.value for feature in ipc.NodeFeatures],
     )
 
 

--- a/astacus/node/cassandra.py
+++ b/astacus/node/cassandra.py
@@ -14,7 +14,7 @@ from astacus.common.cassandra.config import SNAPSHOT_GLOB, SNAPSHOT_NAME
 from astacus.common.exceptions import TransientException
 from pathlib import Path
 from pydantic import DirectoryPath
-from typing import Callable
+from typing import Callable, Tuple
 
 import contextlib
 import logging
@@ -26,6 +26,16 @@ import yaml
 logger = logging.getLogger(__name__)
 
 TABLES_GLOB = "data/*/*"
+
+
+def ks_table_from_snapshot_path(p: Path) -> Tuple[str, str]:
+    # /.../keyspace/table/snapshots/astacus
+    return p.parts[-4], p.parts[-3]
+
+
+def ks_table_from_backup_path(p: Path) -> Tuple[str, str]:
+    # /.../keyspace/table/backups
+    return p.parts[-3], p.parts[-2]
 
 
 class SimpleCassandraSubOp(NodeOp[ipc.NodeRequest, ipc.NodeResult]):
@@ -145,14 +155,8 @@ class CassandraRestoreSSTablesOp(NodeOp[ipc.CassandraRestoreSSTablesRequest, ipc
                 else self._match_table_by_name(keyspace_name, table_name_and_id)
             )
 
-            # Ensure destination path is empty except for potential directories (e.g. backups/)
-            # This should never have anything - except for system_auth, it gets populated when we restore schema.
-            existing_files = [file_path for file_path in table_path.glob("*") if file_path.is_file()]
-            if keyspace_name == "system_auth":
-                for existing_file in existing_files:
-                    existing_file.unlink()
-                existing_files = []
-            assert not existing_files, f"Files found in {table_name_and_id}: {existing_files}"
+            if self.req.expect_empty_target:
+                self._ensure_target_is_empty(keyspace_name=keyspace_name, table_path=table_path)
 
             for file_path in table_snapshot.glob("*"):
                 file_path.rename(table_path / file_path.name)
@@ -174,6 +178,16 @@ class CassandraRestoreSSTablesOp(NodeOp[ipc.CassandraRestoreSSTablesRequest, ipc
         assert len(table_paths) == 1
 
         return table_paths[0]
+
+    def _ensure_target_is_empty(self, *, keyspace_name: str, table_path: Path) -> None:
+        # Ensure destination path is empty except for potential directories (e.g. backups/)
+        # This should never have anything - except for system_auth, it gets populated when we restore schema.
+        existing_files = [file_path for file_path in table_path.glob("*") if file_path.is_file()]
+        if keyspace_name == "system_auth":
+            for existing_file in existing_files:
+                existing_file.unlink()
+            existing_files = []
+        assert not existing_files, f"Files found in {table_path.name}: {existing_files}"
 
 
 class CassandraStartOp(NodeOp[ipc.CassandraStartRequest, ipc.NodeResult]):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -53,6 +53,9 @@ class CassandraTestConfig:
         other_table_path.mkdir(parents=True)
         (other_table_path / "data.file").write_text("data")
 
+        self.backup_path = keyspace_path / "dummytable-123" / "backups"
+        self.backup_path.mkdir(parents=True)
+
         system_schema_path = self.root / "data" / "system_schema" / "tables-789" / "snapshots" / SNAPSHOT_NAME
         system_schema_path.mkdir(parents=True)
         (system_schema_path / "data.file").write_text("schema")
@@ -70,6 +73,8 @@ listen_address: 127.0.0.1
         (self.snapshot_path / "asdf").write_text("foobar")
         (keyspace_path / "dummytable-234").mkdir()
         (keyspace_path / "anothertable-789").mkdir()
+
+        (self.backup_path / "incremental.backup").write_text("delta")
 
         named_temporary_file = mocker.patch.object(tempfile, "NamedTemporaryFile")
         self.fake_conffile = StringIO()

--- a/tests/unit/coordinator/plugins/cassandra/test_restore_steps.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_restore_steps.py
@@ -132,7 +132,7 @@ async def test_step_stop_replaced_nodes(mocker):
     context = SimpleNamespace(get_result=get_result)
     cluster = SimpleNamespace(nodes=nodes)
     result = await step.run_step(cluster, context)
-    assert result is None
+    assert result == [_coordinator_node(1)]
     run_subop.assert_awaited_once_with(
         cluster,
         ipc.CassandraSubOp.stop_cassandra,

--- a/tests/unit/coordinator/plugins/test_base.py
+++ b/tests/unit/coordinator/plugins/test_base.py
@@ -5,13 +5,16 @@ See LICENSE for details
 """
 from astacus.common import ipc, utils
 from astacus.common.asyncstorage import AsyncJsonStorage
+from astacus.common.ipc import Plugin
 from astacus.common.op import Op
 from astacus.common.progress import Progress
 from astacus.common.utils import now
 from astacus.coordinator.cluster import Cluster
 from astacus.coordinator.config import CoordinatorNode
 from astacus.coordinator.plugins.base import (
+    BackupManifestStep,
     ComputeKeptBackupsStep,
+    DeltaManifestsStep,
     ListBackupsStep,
     ListHexdigestsStep,
     SnapshotReleaseStep,
@@ -29,6 +32,7 @@ from tests.unit.json_storage import MemoryJsonStorage
 from typing import AbstractSet, Callable, List, Optional, Sequence
 from unittest import mock
 
+import dataclasses
 import datetime
 import httpx
 import json
@@ -285,3 +289,79 @@ async def test_snapshot_release_step(
         if ipc.NodeFeatures.release_snapshot_files in node_features:
             assert release_request.call_count == 1
             assert status_request.called
+
+
+def make_manifest(start: str, end: str) -> ipc.BackupManifest:
+    manifest = ipc.BackupManifest(
+        start=datetime.datetime.fromisoformat(start),
+        end=datetime.datetime.fromisoformat(end),
+        attempt=1,
+        snapshot_results=[],
+        upload_results=[],
+        plugin=Plugin.files,
+    )
+    return manifest
+
+
+@dataclasses.dataclass
+class TestListDeltasParam:
+    test_id: str
+    basebackup_manifest: ipc.BackupManifest
+    stored_jsons: dict[str, str]
+    expected_deltas: list[str]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "p",
+    [
+        TestListDeltasParam(
+            test_id="empty_storage",
+            basebackup_manifest=make_manifest(start="1970-01-01T00:00", end="1970-01-01T00:30"),
+            stored_jsons={},
+            expected_deltas=[],
+        ),
+        TestListDeltasParam(
+            test_id="single_delta",
+            basebackup_manifest=make_manifest(start="1970-01-01T00:00", end="1970-01-01T00:30"),
+            stored_jsons={
+                "backup-base": make_manifest(start="1970-01-01T00:00", end="1970-01-01T00:30").json(),
+                "delta-one": make_manifest(start="1970-01-01T01:00", end="1970-01-01T01:05").json(),
+            },
+            expected_deltas=["delta-one"],
+        ),
+        TestListDeltasParam(
+            test_id="deltas_older_than_backup_are_not_listed",
+            basebackup_manifest=make_manifest(start="2000-01-01T00:00", end="2000-01-01T00:30"),
+            stored_jsons={
+                "backup-old": make_manifest(start="1970-01-01T00:00", end="1970-01-01T00:30").json(),
+                "delta-old": make_manifest(start="1970-01-01T01:00", end="1970-01-01T01:05").json(),
+                "backup-one": make_manifest(start="2000-01-01T00:00", end="2000-01-01T00:30").json(),
+                "delta-one": make_manifest(start="2000-01-01T01:00", end="2000-01-01T01:05").json(),
+                "delta-two": make_manifest(start="2000-01-01T12:00", end="1970-01-01T12:05").json(),
+                "backup-two": make_manifest(start="2000-01-02T00:00", end="2000-01-02T00:30").json(),
+                "delta-three": make_manifest(start="2000-01-02T12:00", end="2000-01-02T12:05").json(),
+            },
+            expected_deltas=["delta-one", "delta-two", "delta-three"],
+        ),
+        TestListDeltasParam(
+            test_id="relies_on_start_time_in_case_of_intersections",
+            basebackup_manifest=make_manifest(start="2000-01-01T00:00", end="2000-01-01T00:30"),
+            stored_jsons={
+                "delta-old": make_manifest(start="1999-12-31T23:59", end="2000-01-01T00:04").json(),
+                "backup-one": make_manifest(start="2000-01-01T00:00", end="2000-01-01T00:30").json(),
+                "delta-one": make_manifest(start="2000-01-01T00:05", end="2000-01-01T00:10").json(),
+            },
+            expected_deltas=["delta-one"],
+        ),
+    ],
+    ids=lambda p: p.test_id,
+)
+async def test_list_delta_backups(p: TestListDeltasParam) -> None:
+    async_json_storage = AsyncJsonStorage(MemoryJsonStorage(p.stored_jsons))
+    step = DeltaManifestsStep(async_json_storage)
+    cluster = Cluster(nodes=[CoordinatorNode(url="http://node_1")])
+    context = StepsContext()
+    context.set_result(BackupManifestStep, p.basebackup_manifest)
+    backup_names = [b.filename for b in await step.run_step(cluster=cluster, context=context)]
+    assert backup_names == p.expected_deltas


### PR DESCRIPTION
When doing a partial restore, apply all the incremental changes we've
uploaded when creating delta backups. After restoring the snapshot,
download and put sstables from incremental backups into Cassandra's data
directory.