### PR TITLE
snapshotter: Use an SQLite backed snapshotter

### DIFF
--- a/astacus/node/config.py
+++ b/astacus/node/config.py
@@ -66,6 +66,7 @@ class NodeConfig(AstacusModel):
 
     # Same as root_link for the delta snapshotter.
     delta_root_link: Optional[Path]
+    db_path: Optional[Path]
 
     # These can be either globally or locally set
     object_storage: Optional[RohmuConfig] = None

--- a/astacus/node/memory_snapshot.py
+++ b/astacus/node/memory_snapshot.py
@@ -1,0 +1,265 @@
+"""
+
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+
+"""
+
+from astacus.common import magic, utils
+from astacus.common.ipc import SnapshotFile, SnapshotHash
+from astacus.common.progress import increase_worth_reporting, Progress
+from astacus.common.snapshot import SnapshotGroup
+from astacus.node.snapshot import Snapshot
+from astacus.node.snapshotter import hash_hexdigest_readable, Snapshotter
+from glob import iglob
+from pathlib import Path
+from typing import Iterable, Iterator, Mapping, Sequence
+
+import base64
+import dataclasses
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class FoundFile:
+    relative_path: Path
+    group: SnapshotGroup
+
+
+class MemorySnapshot(Snapshot):
+    def __init__(self, dst: Path) -> None:
+        super().__init__(dst)
+        self._relative_path_to_snapshotfile: dict[Path, SnapshotFile] = {}
+        self._hexdigest_to_snapshotfiles: dict[str, list[SnapshotFile]] = {}
+
+    def __len__(self) -> int:
+        return len(self._relative_path_to_snapshotfile)
+
+    def get_file(self, relative_path: Path) -> SnapshotFile | None:
+        return self._relative_path_to_snapshotfile.get(relative_path, None)
+
+    def get_files_for_digest(self, hexdigest: str) -> Iterable[SnapshotFile]:
+        return self._hexdigest_to_snapshotfiles.get(hexdigest, [])
+
+    def get_all_files(self) -> Iterable[SnapshotFile]:
+        return self._relative_path_to_snapshotfile.values()
+
+    def upsert_file(self, file: SnapshotFile) -> None:
+        old_file = self.get_file(file.relative_path)
+        if old_file:
+            self.remove_file(old_file)
+        self._relative_path_to_snapshotfile[file.relative_path] = file
+        if file.hexdigest:
+            self._hexdigest_to_snapshotfiles.setdefault(file.hexdigest, []).append(file)
+
+    def remove_file(self, file: SnapshotFile) -> None:
+        assert self._relative_path_to_snapshotfile[file.relative_path] == file
+        del self._relative_path_to_snapshotfile[file.relative_path]
+        if file.hexdigest:
+            self._hexdigest_to_snapshotfiles[file.hexdigest].remove(file)
+
+    def remove_path(self, relative_path: Path) -> None:
+        file = self.get_file(relative_path)
+        if file is not None:
+            self.remove_file(file)
+
+    def get_all_digests(self) -> Iterable[SnapshotHash]:
+        return (
+            SnapshotHash(hexdigest=file.hexdigest, size=file.file_size)
+            for files in self._hexdigest_to_snapshotfiles.values()
+            for file in files
+        )
+
+
+class MemorySnapshotter(Snapshotter[MemorySnapshot]):
+    def _list_files(self, basepath: Path) -> list[FoundFile]:
+        result_files = set()
+        for group in self._groups:
+            for p in iglob(group.root_glob, root_dir=basepath, recursive=True):
+                path = basepath / p
+                if not path.is_file() or path.is_symlink():
+                    continue
+                if path.name in group.excluded_names:
+                    continue
+                relpath = path.relative_to(basepath)
+                for parent in relpath.parents:
+                    if parent.name == magic.ASTACUS_TMPDIR:
+                        break
+                else:
+                    result_files.add(
+                        FoundFile(
+                            relative_path=relpath,
+                            group=SnapshotGroup(
+                                root_glob=group.root_glob, embedded_file_size_max=group.embedded_file_size_max
+                            ),
+                        )
+                    )
+        return sorted(result_files, key=lambda found_file: found_file.relative_path)
+
+    def _list_dirs_and_files(self, basepath: Path) -> tuple[list[Path], list[FoundFile]]:
+        files = self._list_files(basepath)
+        dirs = {p.relative_path.parent for p in files}
+        return sorted(dirs), files
+
+    def _snapshotfile_from_path(self, relative_path) -> SnapshotFile:
+        src_path = self._src / relative_path
+        st = src_path.stat()
+        return SnapshotFile(relative_path=relative_path, mtime_ns=st.st_mtime_ns, file_size=st.st_size)
+
+    def _get_snapshot_hash_list(self, found_files: Sequence[FoundFile]) -> Iterator[SnapshotFile]:
+        same = 0
+        lost = 0
+        for found_file in found_files:
+            old_snapshotfile = self.snapshot.get_file(found_file.relative_path)
+            try:
+                new_snapshotfile = self._snapshotfile_from_path(found_file.relative_path)
+            except FileNotFoundError:
+                lost += 1
+                if increase_worth_reporting(lost):
+                    logger.info(
+                        "#%d. lost - %s disappeared before stat, ignoring", lost, self._src / found_file.relative_path
+                    )
+                continue
+            if old_snapshotfile and old_snapshotfile.underlying_file_is_the_same(new_snapshotfile):
+                new_snapshotfile.hexdigest = old_snapshotfile.hexdigest
+                new_snapshotfile.content_b64 = old_snapshotfile.content_b64
+                same += 1
+                if increase_worth_reporting(same):
+                    logger.info("#%d. same - %r in %s is same", same, old_snapshotfile, found_file.relative_path)
+                continue
+
+            self._maybe_link(found_file.relative_path)
+            yield new_snapshotfile
+
+    def _snapshot_create_missing_directories(self, *, src_dirs: Sequence[Path], dst_dirs: Sequence[Path]) -> int:
+        changes = 0
+        for i, relative_dir in enumerate(set(src_dirs).difference(dst_dirs), start=1):
+            dst_path = self._dst / relative_dir
+            dst_path.mkdir(parents=True, exist_ok=True)
+            if increase_worth_reporting(i):
+                logger.info("#%d. new directory: %r", i, relative_dir)
+            changes += 1
+        return changes
+
+    def _snapshot_remove_extra_files(self, *, src_files: Sequence[FoundFile], dst_files: Sequence[FoundFile]) -> int:
+        changes = 0
+        for i, found_file in enumerate(set(dst_files).difference(src_files), start=1):
+            dst_path = self._dst / found_file.relative_path
+            snapshotfile = self.snapshot.get_file(found_file.relative_path)
+            if snapshotfile:
+                self.snapshot.remove_file(snapshotfile)
+            dst_path.unlink()
+            if increase_worth_reporting(i):
+                logger.info("#%d. extra file: %r", i, found_file.relative_path)
+            changes += 1
+        return changes
+
+    def _snapshot_add_missing_files(self, *, src_files: Sequence[FoundFile], dst_files: Sequence[FoundFile]) -> int:
+        existing = 0
+        disappeared = 0
+        changes = 0
+        for i, found_file in enumerate(set(src_files).difference(dst_files), start=1):
+            src_path = self._src / found_file.relative_path
+            dst_path = self._dst / found_file.relative_path
+            try:
+                os.link(src=src_path, dst=dst_path, follow_symlinks=False)
+            except FileExistsError:
+                # This happens only if snapshot is started twice at
+                # same time. While it is technically speaking upstream
+                # error, we rather handle it here than leave
+                # exceptions not handled.
+                existing += 1
+                if increase_worth_reporting(existing):
+                    logger.info("#%d. %s already existed, ignoring", existing, src_path)
+                continue
+            except FileNotFoundError:
+                disappeared += 1
+                if increase_worth_reporting(disappeared):
+                    logger.info("#%d. %s disappeared before linking, ignoring", disappeared, src_path)
+                continue
+            if increase_worth_reporting(i - disappeared):
+                logger.info("#%d. new file: %r", i - disappeared, found_file.relative_path)
+            changes += 1
+        return changes
+
+    def perform_snapshot(self, *, progress: Progress) -> None:
+        src_dirs, src_files = self._list_dirs_and_files(self._src)
+        progress.start(1)
+        changes = 0
+        if self._src == self._dst:
+            # The src=dst mode should be used if and only if it is
+            # known that files will not disappear between snapshot and
+            # upload steps (e.g. Astacus controls the lifecycle of the
+            # files within). In that case, there is little point in
+            # making extra symlinks and we can just use the src
+            # directory contents as-is.
+            dst_dirs, dst_files = src_dirs, src_files
+            # When the src and dst files are identical, we can't compare the files of the previous
+            # snapshot, but we still need to cleanup outdated files in relative_path_to_snapshotfile.
+            relative_dst_files = {dst_file.relative_path for dst_file in dst_files}
+            for outdated_relative_path in set(self.snapshot.get_all_paths()) - relative_dst_files:
+                self.snapshot.remove_path(outdated_relative_path)
+        else:
+            progress.add_total(3)
+            dst_dirs, dst_files = self._list_dirs_and_files(self._dst)
+
+            # Create missing directories
+            changes += self._snapshot_create_missing_directories(src_dirs=src_dirs, dst_dirs=dst_dirs)
+            progress.add_success()
+
+            # Remove extra files
+            changes += self._snapshot_remove_extra_files(src_files=src_files, dst_files=dst_files)
+            progress.add_success()
+
+            # Add missing files
+            changes += self._snapshot_add_missing_files(src_files=src_files, dst_files=dst_files)
+            progress.add_success()
+
+            # We COULD also remove extra directories, but it is not
+            # probably really worth it and due to ignored files it
+            # actually might not even work.
+
+            # Then, create/update corresponding snapshotfile objects (old
+            # ones were already removed)
+            dst_dirs, dst_files = self._list_dirs_and_files(self._dst)
+
+        snapshotfiles = list(self._get_snapshot_hash_list(dst_files))
+        progress.add_total(len(snapshotfiles))
+        path_to_group: Mapping[Path, SnapshotGroup] = {dst_file.relative_path: dst_file.group for dst_file in dst_files}
+
+        def _cb(snapshotfile: SnapshotFile) -> SnapshotFile:
+            # src may or may not be present; dst is present as it is in snapshot
+            with snapshotfile.open_for_reading(self._dst) as f:
+                group = path_to_group[snapshotfile.relative_path]
+                if group.embedded_file_size_max is None or snapshotfile.file_size <= group.embedded_file_size_max:
+                    snapshotfile.content_b64 = base64.b64encode(f.read()).decode()
+                else:
+                    snapshotfile.hexdigest = hash_hexdigest_readable(f)
+            return snapshotfile
+
+        def _result_cb(*, map_in: SnapshotFile, map_out: SnapshotFile) -> bool:
+            self.snapshot.upsert_file(map_out)
+            progress.add_success()
+            return True
+
+        changes += len(snapshotfiles)
+        utils.parallel_map_to(iterable=snapshotfiles, fun=_cb, result_callback=_result_cb, n=self._parallel)
+
+        # We initially started with 1 extra
+        progress.add_success()
+
+    def release(self, hexdigests: Iterable[str], *, progress: Progress) -> None:
+        assert self._src != self._dst
+        for hexdigest in progress.wrap(hexdigests):
+            if hexdigest == "":
+                continue
+
+            for snapshotfile in self.snapshot.get_files_for_digest(hexdigest):
+                self._release_file(snapshotfile)
+
+    def _release_file(self, snapshotfile: SnapshotFile) -> None:
+        file = self._dst / snapshotfile.relative_path
+        file.unlink(missing_ok=True)

--- a/astacus/node/snapshot.py
+++ b/astacus/node/snapshot.py
@@ -1,109 +1,45 @@
 """
 
-Copyright (c) 2020 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
-
-General snapshot utilities that are product independent.
-
-Most of the snapshot steps should be implementable by using the API of
-this module with proper parameters.
 
 """
 
-from .node import NodeOp
-from .snapshotter import Snapshotter
-from .uploader import Uploader
-from astacus.common import ipc, utils
-from astacus.common.rohmustorage import RohmuStorage
-from typing import Optional
+from abc import ABC, abstractmethod
+from astacus.common.ipc import SnapshotFile, SnapshotHash
+from pathlib import Path
+from typing import Iterable
 
-import hashlib
-import logging
-
-_hash = hashlib.blake2s
-
-logger = logging.getLogger(__name__)
+import threading
 
 
-class SnapshotOp(NodeOp[ipc.SnapshotRequestV2, ipc.SnapshotResult]):
-    snapshotter: Optional[Snapshotter] = None
+class Snapshot(ABC):
+    def __init__(self, dst: Path) -> None:
+        self.lock = threading.Lock()
+        self.dst = dst
 
-    def create_result(self) -> ipc.SnapshotResult:
-        return ipc.SnapshotResult()
+    @abstractmethod
+    def __len__(self) -> int:
+        ...
 
-    def start(self, snapshotter: Snapshotter) -> NodeOp.StartResult:
-        logger.info("start_snapshot %r", self.req)
-        self.snapshotter = snapshotter
-        return self.start_op(op_name="snapshot", op=self, fun=self.snapshot)
+    @abstractmethod
+    def get_file(self, relative_path: Path) -> SnapshotFile | None:
+        ...
 
-    def snapshot(self) -> None:
-        assert self.snapshotter
-        # 'snapshotter' is global; ensure we have sole access to it
-        with self.snapshotter.lock:
-            self.check_op_id()
-            self.snapshotter.snapshot(progress=self.result.progress)
-            self.result.state = self.snapshotter.get_snapshot_state()
-            self.result.hashes = [
-                ipc.SnapshotHash(hexdigest=ssfile.hexdigest, size=ssfile.file_size)
-                for ssfile in self.result.state.files
-                if ssfile.hexdigest
-            ]
-            self.result.files = len(self.result.state.files)
-            self.result.total_size = sum(ssfile.file_size for ssfile in self.result.state.files)
-            self.result.end = utils.now()
-            self.result.progress.done()
+    @abstractmethod
+    def get_files_for_digest(self, hexdigest: str) -> Iterable[SnapshotFile]:
+        ...
 
+    @abstractmethod
+    def get_all_files(self) -> Iterable[SnapshotFile]:
+        ...
 
-class UploadOp(NodeOp[ipc.SnapshotUploadRequestV20221129, ipc.SnapshotUploadResult]):
-    snapshotter: Optional[Snapshotter] = None
+    def get_all_paths(self) -> Iterable[Path]:
+        return (file.relative_path for file in self.get_all_files())
 
-    @property
-    def storage(self) -> RohmuStorage:
-        assert self.config.object_storage is not None
-        return RohmuStorage(self.config.object_storage, storage=self.req.storage)
+    @abstractmethod
+    def get_all_digests(self) -> Iterable[SnapshotHash]:
+        ...
 
-    def create_result(self) -> ipc.SnapshotUploadResult:
-        return ipc.SnapshotUploadResult()
-
-    def start(self, snapshotter: Snapshotter) -> NodeOp.StartResult:
-        logger.info("start_upload %r", self.req)
-        self.snapshotter = snapshotter
-        return self.start_op(op_name="upload", op=self, fun=self.upload)
-
-    def upload(self) -> None:
-        uploader = Uploader(storage=self.storage)
-        assert self.snapshotter
-        # 'snapshotter' is global; ensure we have sole access to it
-        with self.snapshotter.lock:
-            self.check_op_id()
-            self.result.total_size, self.result.total_stored_size = uploader.write_hashes_to_storage(
-                snapshotter=self.snapshotter,
-                hashes=self.req.hashes,
-                parallel=self.config.parallel.uploads,
-                progress=self.result.progress,
-                still_running_callback=self.still_running_callback,
-                validate_file_hashes=self.req.validate_file_hashes,
-            )
-            self.result.progress.done()
-
-
-class ReleaseOp(NodeOp[ipc.SnapshotReleaseRequest, ipc.NodeResult]):
-    snapshotter: Optional[Snapshotter] = None
-
-    def create_result(self) -> ipc.NodeResult:
-        return ipc.NodeResult()
-
-    def start(self, snapshotter: Snapshotter) -> NodeOp.StartResult:
-        logger.info("start_release %r", self.req)
-        self.snapshotter = snapshotter
-        return self.start_op(op_name="release", op=self, fun=self.release)
-
-    def release(self) -> None:
-        assert self.snapshotter
-        with self.snapshotter.lock:
-            self.check_op_id()
-            self.result.progress.add_total(len(self.req.hexdigests))
-            for hexdigest in self.req.hexdigests:
-                self.snapshotter.release(hexdigest)
-                self.result.progress.add_success()
-            self.result.progress.done()
+    def get_total_size(self) -> int:
+        return sum(file.file_size for file in self.get_all_files())

--- a/astacus/node/snapshot_op.py
+++ b/astacus/node/snapshot_op.py
@@ -1,0 +1,103 @@
+"""
+
+Copyright (c) 2020 Aiven Ltd
+See LICENSE for details
+
+General snapshot utilities that are product independent.
+
+Most of the snapshot steps should be implementable by using the API of
+this module with proper parameters.
+
+"""
+
+from .node import NodeOp
+from .snapshotter import Snapshotter
+from .uploader import Uploader
+from astacus.common import ipc, utils
+from astacus.common.rohmustorage import RohmuStorage
+from astacus.node.snapshot import Snapshot
+from typing import Optional
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class SnapshotOp(NodeOp[ipc.SnapshotRequestV2, ipc.SnapshotResult]):
+    snapshotter: Snapshotter | None = None
+
+    def create_result(self) -> ipc.SnapshotResult:
+        return ipc.SnapshotResult()
+
+    def start(self, snapshotter: Snapshotter) -> NodeOp.StartResult:
+        logger.info("start_snapshot %r", self.req)
+        self.snapshotter = snapshotter
+        return self.start_op(op_name="snapshot", op=self, fun=self.perform_snapshot)
+
+    def perform_snapshot(self) -> None:
+        assert self.snapshotter is not None
+        # 'snapshotter' is global; ensure we have sole access to it
+        with self.snapshotter.lock:
+            self.check_op_id()
+            self.snapshotter.perform_snapshot(progress=self.result.progress)
+            self.result.state = self.snapshotter.get_snapshot_state()
+            self.result.hashes = [
+                ipc.SnapshotHash(hexdigest=ssfile.hexdigest, size=ssfile.file_size)
+                for ssfile in self.result.state.files
+                if ssfile.hexdigest
+            ]
+            self.result.files = len(self.result.state.files)
+            self.result.total_size = sum(ssfile.file_size for ssfile in self.result.state.files)
+            self.result.end = utils.now()
+            self.result.progress.done()
+
+
+class UploadOp(NodeOp[ipc.SnapshotUploadRequestV20221129, ipc.SnapshotUploadResult]):
+    snapshot: Snapshot | None = None
+
+    @property
+    def storage(self) -> RohmuStorage:
+        assert self.config.object_storage is not None
+        return RohmuStorage(self.config.object_storage, storage=self.req.storage)
+
+    def create_result(self) -> ipc.SnapshotUploadResult:
+        return ipc.SnapshotUploadResult()
+
+    def start(self, snapshot: Snapshot) -> NodeOp.StartResult:
+        logger.info("start_upload %r", self.req)
+        self.snapshot = snapshot
+        return self.start_op(op_name="upload", op=self, fun=self.upload)
+
+    def upload(self) -> None:
+        assert self.snapshot is not None
+        uploader = Uploader(storage=self.storage)
+        # 'snapshotter' is global; ensure we have sole access to it
+        with self.snapshot.lock:
+            self.check_op_id()
+            self.result.total_size, self.result.total_stored_size = uploader.write_hashes_to_storage(
+                snapshot=self.snapshot,
+                hashes=self.req.hashes,
+                parallel=self.config.parallel.uploads,
+                progress=self.result.progress,
+                still_running_callback=self.still_running_callback,
+                validate_file_hashes=self.req.validate_file_hashes,
+            )
+            self.result.progress.done()
+
+
+class ReleaseOp(NodeOp[ipc.SnapshotReleaseRequest, ipc.NodeResult]):
+    snapshotter: Optional[Snapshotter] = None
+
+    def create_result(self) -> ipc.NodeResult:
+        return ipc.NodeResult()
+
+    def start(self, snapshotter: Snapshotter) -> NodeOp.StartResult:
+        logger.info("start_release %r", self.req)
+        self.snapshotter = snapshotter
+        return self.start_op(op_name="release", op=self, fun=self.release)
+
+    def release(self) -> None:
+        assert self.snapshotter is not None
+        with self.snapshotter.lock:
+            self.check_op_id()
+            self.snapshotter.release(self.req.hexdigests, progress=self.result.progress)

--- a/astacus/node/snapshotter.py
+++ b/astacus/node/snapshotter.py
@@ -5,21 +5,98 @@ See LICENSE for details
 
 """
 
-from astacus.common import magic, utils
-from astacus.common.ipc import SnapshotFile, SnapshotHash, SnapshotState
-from astacus.common.progress import increase_worth_reporting, Progress
+from abc import ABC, abstractmethod
+from astacus.common.ipc import SnapshotFile, SnapshotState
+from astacus.common.progress import Progress
 from astacus.common.snapshot import SnapshotGroup
+from astacus.node.snapshot import Snapshot
+from multiprocessing import dummy
 from pathlib import Path
-from typing import Iterator, Mapping, Sequence
+from threading import Lock
+from typing import Generic, Iterable, Sequence, TypeVar
 
 import base64
-import dataclasses
 import hashlib
-import logging
 import os
-import threading
 
-logger = logging.getLogger(__name__)
+T = TypeVar("T", bound=Snapshot)
+
+
+class Snapshotter(ABC, Generic[T]):
+    def __init__(self, groups: Sequence[SnapshotGroup], src: Path, dst: Path, snapshot: T, parallel: int) -> None:
+        assert groups  # model has empty; either plugin or configuration must supply them
+        self.snapshot = snapshot
+        self._src = src
+        self._dst = dst
+        self._groups = groups
+        self._parallel = parallel
+        self._dst.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def lock(self) -> Lock:
+        return self.snapshot.lock
+
+    @abstractmethod
+    def perform_snapshot(self, *, progress: Progress) -> None:
+        ...
+
+    @abstractmethod
+    def release(self, hexdigests: Iterable[str], *, progress: Progress) -> None:
+        ...
+
+    def get_snapshot_state(self) -> SnapshotState:
+        return SnapshotState(
+            root_globs=[group.root_glob for group in self._groups], files=list(self.snapshot.get_all_files())
+        )
+
+    def _file_in_src(self, relative_path: Path) -> SnapshotFile:
+        src_path = self._src / relative_path
+        st = src_path.stat()
+        return SnapshotFile(relative_path=relative_path, mtime_ns=st.st_mtime_ns, file_size=st.st_size)
+
+    def _compute_digests(self, files: Iterable[SnapshotFile]) -> Iterable[SnapshotFile]:
+        def _cb(snapshotfile: SnapshotFile) -> SnapshotFile:
+            # src may or may not be present; dst is present as it is in snapshot
+            with snapshotfile.open_for_reading(self._dst) as f:
+                embedded_file_size_max = self._embedded_file_size_max_for_file(snapshotfile)
+                if embedded_file_size_max is None or snapshotfile.file_size <= embedded_file_size_max:
+                    if snapshotfile.content_b64 is None:
+                        snapshotfile.content_b64 = base64.b64encode(f.read()).decode()
+                else:
+                    if snapshotfile.hexdigest == "":
+                        snapshotfile.hexdigest = hash_hexdigest_readable(f)
+            return snapshotfile
+
+        with dummy.Pool(self._parallel) as p:
+            yield from p.imap_unordered(_cb, files)
+
+    def _embedded_file_size_max_for_file(self, file: SnapshotFile) -> int | None:
+        groups = []
+        for group in self._groups:
+            if file.relative_path.match(group.root_glob):
+                groups.append(group)
+        assert groups
+        head, *tail = groups
+        for group in tail:
+            if not group.embedded_file_size_max == head.embedded_file_size_max:
+                raise ValueError("All SnapshotGroups containing a common file must have the same embedded_file_size_max")
+        return head.embedded_file_size_max
+
+    def _maybe_link(self, relpath: Path) -> None:
+        """Links the src to the dst if we are not in same root mode.
+        If dst exists, it is unlinked first.
+        """
+        if self._same_root_mode():
+            return
+
+        src = self._src / relpath
+        dst = self._dst / relpath
+        dst.unlink(missing_ok=True)
+        os.link(src=src, dst=dst, follow_symlinks=False)
+
+    def _same_root_mode(self) -> bool:
+        return self._src.samefile(self._dst)
+
 
 _hash = hashlib.blake2s
 
@@ -32,254 +109,3 @@ def hash_hexdigest_readable(f, *, read_buffer: int = 1_000_000) -> str:
             break
         h.update(data)
     return h.hexdigest()
-
-
-@dataclasses.dataclass(frozen=True, slots=True)
-class FoundFile:
-    relative_path: Path
-    group: SnapshotGroup
-
-
-class Snapshotter:
-    """Snapshotter keeps track of files on disk, and their hashes.
-
-    The hash on disk MAY change, which may require subsequent
-    incremential snapshot and-or ignoring the files which have changed.
-
-    The output to outside is just root object's hash, as well as list
-    of other hashes which correspond to files referred to within the
-    file list contained in root object.
-
-    Note that any call to public API MUST be made with
-    snapshotter.lock held. This is because Snapshotter is process-wide
-    utility that is shared across operations, possibly used from
-    multiple threads, and the single-operation-only mode of operation
-    is not exactly flawless (the 'new operation can be started with
-    old running' is intentional feature but new operation should
-    eventually replace the old). The lock itself might not need to be
-    built-in to Snapshotter, but having it there enables asserting its
-    state during public API calls.
-    """
-
-    def __init__(self, *, src: Path, dst: Path, groups: Sequence[SnapshotGroup], parallel: int) -> None:
-        assert groups  # model has empty; either plugin or configuration must supply them
-        self.src = src
-        self.dst = dst
-        self.groups = groups
-        self.relative_path_to_snapshotfile: dict[Path, SnapshotFile] = {}
-        self.hexdigest_to_snapshotfiles: dict[str, list[SnapshotFile]] = {}
-        self.parallel = parallel
-        self.lock = threading.Lock()
-
-    def _list_files(self, basepath: Path) -> list[FoundFile]:
-        result_files = set()
-        for group in self.groups:
-            for path in basepath.glob(group.root_glob):
-                if not path.is_file() or path.is_symlink():
-                    continue
-                if path.name in group.excluded_names:
-                    continue
-                relpath = path.relative_to(basepath)
-                for parent in relpath.parents:
-                    if parent.name == magic.ASTACUS_TMPDIR:
-                        break
-                else:
-                    result_files.add(
-                        FoundFile(
-                            relative_path=relpath,
-                            group=SnapshotGroup(
-                                root_glob=group.root_glob, embedded_file_size_max=group.embedded_file_size_max
-                            ),
-                        )
-                    )
-        return sorted(result_files, key=lambda found_file: found_file.relative_path)
-
-    def _list_dirs_and_files(self, basepath: Path) -> tuple[list[Path], list[FoundFile]]:
-        files = self._list_files(basepath)
-        dirs = {p.relative_path.parent for p in files}
-        return sorted(dirs), files
-
-    def _add_snapshotfile(self, snapshotfile: SnapshotFile) -> None:
-        old_snapshotfile = self.relative_path_to_snapshotfile.get(snapshotfile.relative_path, None)
-        if old_snapshotfile:
-            self._remove_snapshotfile(old_snapshotfile)
-        self.relative_path_to_snapshotfile[snapshotfile.relative_path] = snapshotfile
-        if snapshotfile.hexdigest:
-            self.hexdigest_to_snapshotfiles.setdefault(snapshotfile.hexdigest, []).append(snapshotfile)
-
-    def _remove_snapshotfile(self, snapshotfile: SnapshotFile) -> None:
-        assert self.relative_path_to_snapshotfile[snapshotfile.relative_path] == snapshotfile
-        del self.relative_path_to_snapshotfile[snapshotfile.relative_path]
-        if snapshotfile.hexdigest:
-            self.hexdigest_to_snapshotfiles[snapshotfile.hexdigest].remove(snapshotfile)
-
-    def _release_snapshotfile(self, snapshotfile: SnapshotFile) -> None:
-        dst_path = self.dst / snapshotfile.relative_path
-        dst_path.unlink(missing_ok=True)
-
-    def _snapshotfile_from_path(self, relative_path) -> SnapshotFile:
-        src_path = self.src / relative_path
-        st = src_path.stat()
-        return SnapshotFile(relative_path=relative_path, mtime_ns=st.st_mtime_ns, file_size=st.st_size)
-
-    def _get_snapshot_hash_list(self, found_files: Sequence[FoundFile]) -> Iterator[SnapshotFile]:
-        same = 0
-        lost = 0
-        for found_file in found_files:
-            old_snapshotfile = self.relative_path_to_snapshotfile.get(found_file.relative_path)
-            try:
-                new_snapshotfile = self._snapshotfile_from_path(found_file.relative_path)
-            except FileNotFoundError:
-                lost += 1
-                if increase_worth_reporting(lost):
-                    logger.info(
-                        "#%d. lost - %s disappeared before stat, ignoring", lost, self.src / found_file.relative_path
-                    )
-                continue
-            if old_snapshotfile and old_snapshotfile.underlying_file_is_the_same(new_snapshotfile):
-                new_snapshotfile.hexdigest = old_snapshotfile.hexdigest
-                new_snapshotfile.content_b64 = old_snapshotfile.content_b64
-                same += 1
-                if increase_worth_reporting(same):
-                    logger.info("#%d. same - %r in %s is same", same, old_snapshotfile, found_file.relative_path)
-                continue
-
-            yield new_snapshotfile
-
-    def get_snapshot_hashes(self) -> list[SnapshotHash]:
-        assert self.lock.locked()
-        return [
-            SnapshotHash(hexdigest=dig, size=sf[0].file_size) for dig, sf in self.hexdigest_to_snapshotfiles.items() if sf
-        ]
-
-    def get_snapshot_state(self) -> SnapshotState:
-        assert self.lock.locked()
-        return SnapshotState(
-            root_globs=[group.root_glob for group in self.groups], files=sorted(self.relative_path_to_snapshotfile.values())
-        )
-
-    def _snapshot_create_missing_directories(self, *, src_dirs: Sequence[Path], dst_dirs: Sequence[Path]) -> int:
-        changes = 0
-        for i, relative_dir in enumerate(set(src_dirs).difference(dst_dirs), start=1):
-            dst_path = self.dst / relative_dir
-            dst_path.mkdir(parents=True, exist_ok=True)
-            if increase_worth_reporting(i):
-                logger.info("#%d. new directory: %r", i, relative_dir)
-            changes += 1
-        return changes
-
-    def _snapshot_remove_extra_files(self, *, src_files: Sequence[FoundFile], dst_files: Sequence[FoundFile]) -> int:
-        changes = 0
-        for i, found_file in enumerate(set(dst_files).difference(src_files), start=1):
-            dst_path = self.dst / found_file.relative_path
-            snapshotfile = self.relative_path_to_snapshotfile.get(found_file.relative_path)
-            if snapshotfile:
-                self._remove_snapshotfile(snapshotfile)
-            dst_path.unlink()
-            if increase_worth_reporting(i):
-                logger.info("#%d. extra file: %r", i, found_file.relative_path)
-            changes += 1
-        return changes
-
-    def _snapshot_add_missing_files(self, *, src_files: Sequence[FoundFile], dst_files: Sequence[FoundFile]) -> int:
-        existing = 0
-        disappeared = 0
-        changes = 0
-        for i, found_file in enumerate(set(src_files).difference(dst_files), start=1):
-            src_path = self.src / found_file.relative_path
-            dst_path = self.dst / found_file.relative_path
-            try:
-                os.link(src=src_path, dst=dst_path, follow_symlinks=False)
-            except FileExistsError:
-                # This happens only if snapshot is started twice at
-                # same time. While it is technically speaking upstream
-                # error, we rather handle it here than leave
-                # exceptions not handled.
-                existing += 1
-                if increase_worth_reporting(existing):
-                    logger.info("#%d. %s already existed, ignoring", existing, src_path)
-                continue
-            except FileNotFoundError:
-                disappeared += 1
-                if increase_worth_reporting(disappeared):
-                    logger.info("#%d. %s disappeared before linking, ignoring", disappeared, src_path)
-                continue
-            if increase_worth_reporting(i - disappeared):
-                logger.info("#%d. new file: %r", i - disappeared, found_file.relative_path)
-            changes += 1
-        return changes
-
-    def snapshot(self, *, progress: Progress) -> int:
-        assert self.lock.locked()
-        src_dirs, src_files = self._list_dirs_and_files(self.src)
-        progress.start(1)
-        changes = 0
-        if self.src == self.dst:
-            # The src=dst mode should be used if and only if it is
-            # known that files will not disappear between snapshot and
-            # upload steps (e.g. Astacus controls the lifecycle of the
-            # files within). In that case, there is little point in
-            # making extra symlinks and we can just use the src
-            # directory contents as-is.
-            dst_dirs, dst_files = src_dirs, src_files
-            # When the src and dst files are identical, we can't compare the files of the previous
-            # snapshot, but we still need to cleanup outdated files in relative_path_to_snapshotfile.
-            relative_dst_files = {dst_file.relative_path for dst_file in dst_files}
-            for outdated_relative_path in set(self.relative_path_to_snapshotfile) - relative_dst_files:
-                self._remove_snapshotfile(self.relative_path_to_snapshotfile[outdated_relative_path])
-        else:
-            progress.add_total(3)
-            dst_dirs, dst_files = self._list_dirs_and_files(self.dst)
-
-            # Create missing directories
-            changes += self._snapshot_create_missing_directories(src_dirs=src_dirs, dst_dirs=dst_dirs)
-            progress.add_success()
-
-            # Remove extra files
-            changes += self._snapshot_remove_extra_files(src_files=src_files, dst_files=dst_files)
-            progress.add_success()
-
-            # Add missing files
-            changes += self._snapshot_add_missing_files(src_files=src_files, dst_files=dst_files)
-            progress.add_success()
-
-            # We COULD also remove extra directories, but it is not
-            # probably really worth it and due to ignored files it
-            # actually might not even work.
-
-            # Then, create/update corresponding snapshotfile objects (old
-            # ones were already removed)
-            dst_dirs, dst_files = self._list_dirs_and_files(self.dst)
-
-        snapshotfiles = list(self._get_snapshot_hash_list(dst_files))
-        progress.add_total(len(snapshotfiles))
-        path_to_group: Mapping[Path, SnapshotGroup] = {dst_file.relative_path: dst_file.group for dst_file in dst_files}
-
-        def _cb(snapshotfile: SnapshotFile) -> SnapshotFile:
-            # src may or may not be present; dst is present as it is in snapshot
-            with snapshotfile.open_for_reading(self.dst) as f:
-                group = path_to_group[snapshotfile.relative_path]
-                if group.embedded_file_size_max is None or snapshotfile.file_size <= group.embedded_file_size_max:
-                    snapshotfile.content_b64 = base64.b64encode(f.read()).decode()
-                else:
-                    snapshotfile.hexdigest = hash_hexdigest_readable(f)
-            return snapshotfile
-
-        def _result_cb(*, map_in: SnapshotFile, map_out: SnapshotFile) -> bool:
-            self._add_snapshotfile(map_out)
-            progress.add_success()
-            return True
-
-        changes += len(snapshotfiles)
-        utils.parallel_map_to(iterable=snapshotfiles, fun=_cb, result_callback=_result_cb, n=self.parallel)
-
-        # We initially started with 1 extra
-        progress.add_success()
-
-        return changes
-
-    def release(self, hexdigest: str) -> None:
-        assert self.lock.locked()
-        assert self.src != self.dst
-        for snapshotfile in self.hexdigest_to_snapshotfiles.get(hexdigest, []):
-            self._release_snapshotfile(snapshotfile)

--- a/astacus/node/sqlite_snapshot.py
+++ b/astacus/node/sqlite_snapshot.py
@@ -1,0 +1,255 @@
+"""
+
+Copyright (c) 2023 Aiven Ltd
+See LICENSE for details
+
+"""
+from astacus.common import magic
+from astacus.common.ipc import SnapshotFile, SnapshotHash
+from astacus.common.progress import Progress
+from astacus.common.snapshot import SnapshotGroup
+from astacus.node.snapshot import Snapshot
+from astacus.node.snapshotter import Snapshotter
+from contextlib import closing
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Iterable, Sequence
+from typing_extensions import override
+
+import os
+import sqlite3
+
+
+class SQLiteSnapshot(Snapshot):
+    def __init__(self, dst: Path, db: Path) -> None:
+        self.db = db
+        if db.exists():
+            # We could probably use an old db again since everything should be
+            # in a transaction, but there is little benefit so let's be safe and
+            # just recreate it.
+            db.unlink()
+        else:
+            db.parent.mkdir(parents=True, exist_ok=True)
+        self._con = sqlite3.connect(db, isolation_level=None, check_same_thread=False)
+        self._con.executescript(
+            """
+            begin;
+            create table snapshot_files (
+                relative_path text not null,
+                file_size integer not null,
+                mtime_ns integer not null,
+                hexdigest text not null,
+                content_b64 text,
+                primary key (relative_path)
+            );
+            create index snapshot_files_hexdigest on snapshot_files(hexdigest);
+            commit;
+            """
+        )
+        super().__init__(dst)
+
+    def __len__(self) -> int:
+        return self._con.execute("select count(*) from snapshot_files;").fetchone()[0]
+
+    def get_file(self, relative_path: Path) -> SnapshotFile | None:
+        cur = self._con.execute("select * from snapshot_files where relative_path = ?;", (str(relative_path),))
+        row = cur.fetchone()
+        return row_to_snapshotfile(row) if row else None
+
+    def get_files_for_digest(self, hexdigest: str) -> Iterable[SnapshotFile]:
+        return map(
+            row_to_snapshotfile,
+            self._con.execute(
+                """
+                select *
+                from snapshot_files
+                where hexdigest = ?
+                order by relative_path;
+                """,
+                (hexdigest,),
+            ),
+        )
+
+    def get_all_files(self) -> Iterable[SnapshotFile]:
+        return map(row_to_snapshotfile, self._con.execute("select * from snapshot_files order by relative_path;"))
+
+    @override
+    def get_all_paths(self) -> Iterable[Path]:
+        return (
+            Path(row[0]) for row in self._con.execute("select relative_path from snapshot_files order by relative_path;")
+        )
+
+    @override
+    def get_total_size(self) -> int:
+        return self._con.execute("select sum(file_size) from snapshot_files;").fetchone()[0] or 0
+
+    def get_connection(self) -> sqlite3.Connection:
+        return self._con
+
+    def get_all_digests(self) -> Iterable[SnapshotHash]:
+        for hexdigest, file_size in self._con.execute(
+            """
+            select hexdigest, file_size
+            from snapshot_files
+            where hexdigest != ''
+            order by hexdigest;
+            """
+        ):
+            yield SnapshotHash(hexdigest=hexdigest, size=file_size)
+
+
+class SQLiteSnapshotter(Snapshotter[SQLiteSnapshot]):
+    def __init__(
+        self, groups: Sequence[SnapshotGroup], src: Path, dst: Path, snapshot: SQLiteSnapshot, parallel: int
+    ) -> None:
+        super().__init__(groups, src, dst, snapshot, parallel)
+        self._con = snapshot.get_connection()
+
+    def perform_snapshot(self, *, progress: Progress) -> None:
+        files = self._list_files_and_create_directories()
+        new_or_existing = self._compare_current_snapshot(files)
+        for_upsert = self._compare_with_src(new_or_existing)
+        with_digests = self._compute_digests(for_upsert)
+        self._upsert_files(with_digests)
+        self._con.execute("drop table if exists new_files;")
+        self._con.commit()
+
+    def _list_files_and_create_directories(self) -> Iterable[Path]:
+        """List all files, and create directories in src."""
+        for dir_, _, files in os.walk(self._src):
+            dir_path = Path(dir_)
+            if any(parent.name == magic.ASTACUS_TMPDIR for parent in dir_path.parents):
+                continue
+            rel_dir = dir_path.relative_to(self._src)
+            (self._dst / rel_dir).mkdir(parents=True, exist_ok=True)
+            for f in files:
+                rel_path = rel_dir / f
+                full_path = dir_path / f
+                if full_path.is_symlink():
+                    continue
+                for group in self._groups:
+                    # fnmatch works strangely with paths until 3.13 so convert to string
+                    # https://github.com/python/cpython/issues/73435
+                    if fnmatch(str(rel_path), group.root_glob) and f not in group.excluded_names:
+                        yield rel_path
+                        break
+
+    def _compare_current_snapshot(self, files: Iterable[Path]) -> Iterable[tuple[Path, SnapshotFile | None]]:
+        with closing(self._con.cursor()) as cur:
+            cur.execute(
+                """
+                create temporary table current_files (
+                    relative_path text not null
+                );
+                """
+            )
+            cur.execute(
+                """
+                create temporary table new_files (
+                    relative_path text not null,
+                    file_size integer,
+                    mtime_ns integer,
+                    hexdigest text,
+                    content_b64 text
+                );
+                """
+            )
+            cur.executemany("insert into current_files (relative_path) values (?);", ((str(f),) for f in files))
+            cur.execute(
+                """
+                delete from snapshot_files
+                where relative_path
+                not in (select relative_path from current_files)
+                returning relative_path;
+                """
+            )
+            if not self._same_root_mode():
+                for (relative_path,) in cur:
+                    os.unlink(self._dst / relative_path)
+            self._con.commit()
+            cur.execute(
+                """
+                insert into new_files
+                select *
+                from snapshot_files
+                natural join current_files;
+                """
+            )
+            cur.execute(
+                """
+                insert into new_files
+                select relative_path, null, null, null, null
+                from current_files
+                where relative_path
+                not in (
+                    select relative_path
+                    from snapshot_files
+                );
+                """
+            )
+            cur.execute("drop table current_files;")
+            cur.execute(
+                """
+                select relative_path, file_size, mtime_ns, hexdigest, content_b64
+                from new_files;
+                """
+            )
+            for row in cur:
+                if row[1] is None:
+                    yield Path(row[0]), None
+                else:
+                    yield Path(row[0]), row_to_snapshotfile(row)
+
+    def _compare_with_src(self, files: Iterable[tuple[Path, SnapshotFile | None]]) -> Iterable[SnapshotFile]:
+        for relpath, existing in files:
+            new = self._file_in_src(relpath)
+            if existing is None or not existing.underlying_file_is_the_same(new):
+                self._maybe_link(relpath)
+                yield new
+
+    def _upsert_files(self, files: Iterable[SnapshotFile]) -> None:
+        self._con.executemany(
+            """
+            insert or replace
+            into snapshot_files
+                (relative_path, file_size, mtime_ns, hexdigest, content_b64)
+            values (?, ?, ?, ?, ?);
+            """,
+            ((str(f.relative_path), f.file_size, f.mtime_ns, f.hexdigest, f.content_b64) for f in files),
+        )
+
+    def release(self, hexdigests: Iterable[str], *, progress: Progress) -> None:
+        with closing(self._con.cursor()) as cur:
+            cur.execute(
+                """
+                create temporary table hexdigests (
+                    hexdigest text not null
+                );
+                """
+            )
+            cur.executemany(
+                "insert into hexdigests (hexdigest) values (?);",
+                ((h,) for h in hexdigests if h != ""),
+            )
+            cur.execute(
+                """
+                select relative_path
+                from snapshot_files
+                where hexdigest in (select hexdigest from hexdigests);
+                """
+            )
+            for (relative_path,) in cur:
+                (self._dst / relative_path).unlink(missing_ok=True)
+            cur.execute("drop table hexdigests;")
+
+
+def row_to_path_and_snapshotfile(row: tuple) -> tuple[Path, SnapshotFile | None]:
+    return Path(row[0]), row_to_snapshotfile(row)
+
+
+def row_to_snapshotfile(row: tuple) -> SnapshotFile:
+    return SnapshotFile(relative_path=Path(row[0]), file_size=row[1], mtime_ns=row[2], hexdigest=row[3], content_b64=row[4])
+
+
+def snapshotfile_to_row(file: SnapshotFile) -> tuple[str, int, int, str, str | None]:
+    return (str(file.relative_path), file.file_size, file.mtime_ns, file.hexdigest, file.content_b64)

--- a/astacus/node/uploader.py
+++ b/astacus/node/uploader.py
@@ -5,10 +5,13 @@ See LICENSE for details
 
 """
 
-from .snapshotter import hash_hexdigest_readable, Snapshotter
+from .snapshotter import hash_hexdigest_readable
 from astacus.common import exceptions, utils
+from astacus.common.ipc import SnapshotFile, SnapshotHash
 from astacus.common.progress import Progress
 from astacus.common.storage import ThreadLocalStorage
+from astacus.node.snapshot import Snapshot
+from typing import Sequence
 
 import logging
 
@@ -19,35 +22,40 @@ class Uploader(ThreadLocalStorage):
     def write_hashes_to_storage(
         self,
         *,
-        snapshotter: Snapshotter,
-        hashes,
+        snapshot: Snapshot,
+        hashes: Sequence[SnapshotHash],
         parallel: int,
         progress: Progress,
         still_running_callback=lambda: True,
         validate_file_hashes: bool = True
     ):
-        todo = set(hash.hexdigest for hash in hashes)
+        todo = [
+            (hexdigest, list(snapshot.get_files_for_digest(hexdigest)))
+            for hexdigest in set(hash.hexdigest for hash in hashes)
+        ]
+        todo.sort(key=lambda hexdigest_and_files: -hexdigest_and_files[1][0].file_size)
         progress.start(len(todo))
         sizes = {"total": 0, "stored": 0}
 
-        def _upload_hexdigest_in_thread(hexdigest):
+        def _upload_hexdigest_in_thread(work: tuple[str, list[SnapshotFile]]):
+            hexdigest, files = work
             storage = self.local_storage
 
             assert hexdigest
-            files = snapshotter.hexdigest_to_snapshotfiles.get(hexdigest, [])
+            files = list(snapshot.get_files_for_digest(hexdigest))
             for snapshotfile in files:
-                path = snapshotter.dst / snapshotfile.relative_path
+                path = snapshot.dst / snapshotfile.relative_path
                 if not path.is_file():
                     logger.warning("%s disappeared post-snapshot", path)
                     continue
                 if validate_file_hashes:
-                    with snapshotfile.open_for_reading(snapshotter.dst) as f:
+                    with snapshotfile.open_for_reading(snapshot.dst) as f:
                         current_hexdigest = hash_hexdigest_readable(f)
                     if current_hexdigest != snapshotfile.hexdigest:
                         logger.info("Hash of %s changed before upload", snapshotfile.relative_path)
                         continue
                 try:
-                    with snapshotfile.open_for_reading(snapshotter.dst) as f:
+                    with snapshotfile.open_for_reading(snapshot.dst) as f:
                         upload_result = storage.upload_hexdigest_from_file(hexdigest, f, file_size=snapshotfile.file_size)
                 except exceptions.TransientException as ex:
                     # Do not pollute logs with transient exceptions
@@ -58,7 +66,7 @@ class Uploader(ThreadLocalStorage):
                     logger.exception("Exception uploading %r", path)
                     return progress.upload_failure, 0, 0
                 if validate_file_hashes:
-                    with snapshotfile.open_for_reading(snapshotter.dst) as f:
+                    with snapshotfile.open_for_reading(snapshot.dst) as f:
                         current_hexdigest = hash_hexdigest_readable(f)
                     if current_hexdigest != snapshotfile.hexdigest:
                         logger.info("Hash of %s changed after upload", snapshotfile.relative_path)
@@ -78,9 +86,6 @@ class Uploader(ThreadLocalStorage):
             progress_callback(map_in)  # hexdigest
             return still_running_callback()
 
-        sorted_todo = sorted(todo, key=lambda hexdigest: -snapshotter.hexdigest_to_snapshotfiles[hexdigest][0].file_size)
-        if not utils.parallel_map_to(
-            fun=_upload_hexdigest_in_thread, iterable=sorted_todo, result_callback=_result_cb, n=parallel
-        ):
+        if not utils.parallel_map_to(fun=_upload_hexdigest_in_thread, iterable=todo, result_callback=_result_cb, n=parallel):
             progress.add_fail()
         return sizes["total"], sizes["stored"]

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -130,12 +130,12 @@ async def wait_url_up(url: Union[URL, str]) -> None:
 
 
 @pytest.fixture(name="rootdir")
-def fixture_rootdir(pytestconfig):
+def fixture_rootdir(pytestconfig) -> str:
     return os.path.join(os.path.dirname(__file__), "..", "..")
 
 
 @asynccontextmanager
-async def _astacus(*, tmpdir, index):
+async def _astacus(*, tmpdir, index: int) -> AsyncIterator[TestNode]:
     node = ASTACUS_NODES[index]
     a_conf_path = create_astacus_config(tmpdir=tmpdir, node=node)
     astacus_source_root = os.path.join(os.path.dirname(__file__), "..", "..")
@@ -154,19 +154,19 @@ async def _astacus(*, tmpdir, index):
 
 
 @pytest.fixture(name="astacus1")
-async def fixture_astacus1(tmpdir):
+async def fixture_astacus1(tmpdir) -> AsyncIterator[TestNode]:
     async with _astacus(tmpdir=tmpdir, index=0) as a:
         yield a
 
 
 @pytest.fixture(name="astacus2")
-async def fixture_astacus2(tmpdir):
+async def fixture_astacus2(tmpdir) -> AsyncIterator[TestNode]:
     async with _astacus(tmpdir=tmpdir, index=1) as a:
         yield a
 
 
 @pytest.fixture(name="astacus3")
-async def fixture_astacus3(tmpdir):
+async def fixture_astacus3(tmpdir) -> AsyncIterator[TestNode]:
     async with _astacus(tmpdir=tmpdir, index=2) as a:
         yield a
 

--- a/tests/system/test_astacus.py
+++ b/tests/system/test_astacus.py
@@ -7,7 +7,7 @@ Basic backup-restore cycle and its variations
 """
 
 from astacus.common import magic
-from tests.system.conftest import astacus_ls, astacus_run
+from tests.system.conftest import astacus_ls, astacus_run, TestNode
 
 import logging
 import pytest
@@ -27,8 +27,10 @@ A1_FILES_AND_CONTENTS = [
 
 # This test is the slowest, so rather fail fast in real unittests before getting here
 @pytest.mark.order("last")
-@pytest.mark.asyncio
-async def test_astacus(astacus1, astacus2, astacus3, rootdir):
+def test_astacus(astacus1: TestNode, astacus2: TestNode, astacus3: TestNode, rootdir: str):
+    assert astacus1.root_path
+    assert astacus2.root_path
+    assert astacus3.root_path
     # Idea:
     # Store following files
     # a1 - A1_FILES_AND_CONTENTS

--- a/tests/unit/node/test_snapshotter.py
+++ b/tests/unit/node/test_snapshotter.py
@@ -4,61 +4,144 @@ See LICENSE for details
 """
 from astacus.common.progress import Progress
 from astacus.common.snapshot import SnapshotGroup
-from astacus.node.snapshotter import hash_hexdigest_readable, Snapshotter
+from astacus.node.memory_snapshot import MemorySnapshot
+from astacus.node.snapshot import Snapshot
+from astacus.node.snapshotter import hash_hexdigest_readable
+from astacus.node.sqlite_snapshot import SQLiteSnapshot
+from io import BytesIO
 from pathlib import Path
+from tests.unit.node.conftest import build_snapshot_and_snapshotter, create_files_at_path
+from time import sleep
+
+import base64
+import pytest
 
 
-def test_snapshotter_with_src_equal_dst_forgets_file_from_previous_snapshot(tmp_path: Path) -> None:
-    src_and_dst = tmp_path
-    file_before = src_and_dst / "file_before"
-    file_before.write_bytes(b"x" * 1024)
-    snapshotter = Snapshotter(src=src_and_dst, dst=src_and_dst, groups=[SnapshotGroup(root_glob="*")], parallel=1)
-    with snapshotter.lock:
-        snapshotter.snapshot(progress=Progress())
-        assert snapshotter.relative_path_to_snapshotfile.keys() == {Path("file_before")}
-        file_before.unlink()
-        file_after = src_and_dst / "file_after"
-        file_after.write_bytes(b"y" * 1024)
-        snapshotter.snapshot(progress=Progress())
-        assert snapshotter.relative_path_to_snapshotfile.keys() == {Path("file_after")}
+@pytest.mark.parametrize("snapshot_cls", [MemorySnapshot, SQLiteSnapshot])
+@pytest.mark.parametrize("src_is_dst", [True, False])
+def test_snapshotter(snapshot_cls: type[Snapshot], src: Path, dst: Path, db: Path, src_is_dst: bool) -> None:
+    if src_is_dst:
+        dst = src
+    groups = [
+        SnapshotGroup(root_glob="**/aa*", embedded_file_size_max=100),
+        SnapshotGroup(root_glob="bb*", embedded_file_size_max=1),
+        SnapshotGroup(root_glob="folder2/*c", embedded_file_size_max=None),
+    ]
+    snapshot, snapshotter = build_snapshot_and_snapshotter(src, dst, db, snapshot_cls, groups)
+    matched_under_embedded_file_size_max = [(Path("folder1") / "aaa", b"aaaaa"), (Path("folder2") / "ccc", b"ccccc")]
+    matched_over_embedded_file_size_max = [(Path("bbb"), b"bbbbb")]
+    not_matched = [(Path("ddd"), b"ddddd"), (Path("eee"), b"eeeee")]
+    create_files_at_path(src, matched_under_embedded_file_size_max + matched_over_embedded_file_size_max + not_matched)
+    snapshotter.perform_snapshot(progress=Progress())
+    assert len(snapshot) == 3
+    for path, content in matched_under_embedded_file_size_max + matched_over_embedded_file_size_max:
+        snapshotfile = snapshot.get_file(path)
+        assert snapshotfile is not None
+        assert snapshotfile.relative_path == path
+        assert snapshotfile.file_size == len(content)
+        file = dst / path
+        assert file.read_bytes() == content
+        st = file.stat()
+        assert snapshotfile.mtime_ns == st.st_mtime_ns
+        assert snapshotfile.file_size == st.st_size
+    for path, content in not_matched:
+        snapshotfile = snapshot.get_file(path)
+        assert snapshotfile is None
+    for path, content in matched_over_embedded_file_size_max:
+        snapshotfile = snapshot.get_file(path)
+        assert snapshotfile is not None
+        assert snapshotfile.hexdigest == hash_hexdigest_readable(BytesIO(content))
+        assert snapshotfile.content_b64 is None
+    for path, content in matched_under_embedded_file_size_max:
+        snapshotfile = snapshot.get_file(path)
+        assert snapshotfile is not None
+        assert snapshotfile.hexdigest == ""
+        assert snapshotfile.content_b64 == base64.b64encode(content).decode()
 
 
-def assert_kept(hexdigest: str, dst_path: Path, snapshotter: Snapshotter):
-    assert dst_path.exists()
-    assert hexdigest in snapshotter.hexdigest_to_snapshotfiles
-    assert Path(dst_path.name) in snapshotter.relative_path_to_snapshotfile
+@pytest.mark.parametrize("snapshot_cls", [MemorySnapshot, SQLiteSnapshot])
+@pytest.mark.parametrize("src_is_dst", [True, False])
+@pytest.mark.parametrize("new_file_size", [1024, 2048])
+@pytest.mark.parametrize("embedded_file_size_max", [None, 1, 1500, 3000])
+@pytest.mark.parametrize("path", [Path("abc123"), Path("folder") / "abc123"])
+def test_snapshotter_updates_changed_file(
+    snapshot_cls: type[Snapshot],
+    src: Path,
+    dst: Path,
+    db: Path,
+    src_is_dst: bool,
+    new_file_size: int,
+    embedded_file_size_max: int,
+    path: Path,
+) -> None:
+    if src_is_dst:
+        dst = src
+    contents = b"x" * 1024
+    create_files_at_path(src, [(path, contents)])
+    groups = [SnapshotGroup(root_glob="**", embedded_file_size_max=embedded_file_size_max)]
+    snapshot, snapshotter = build_snapshot_and_snapshotter(src, dst, db, snapshot_cls, groups)
+    snapshotter.perform_snapshot(progress=Progress())
+    assert len(snapshot) == 1
+    assert snapshot.get_file(path) is not None
+    new_contents = b"y" * new_file_size
+    if new_file_size == 1024:
+        # Make sure mtimes are different
+        sleep(0.01)
+    create_files_at_path(src, [(path, new_contents)])
+    snapshotter.perform_snapshot(progress=Progress())
+    assert len(snapshot) == 1
+    snapshotfile = snapshot.get_file(path)
+    assert snapshotfile is not None
+    assert snapshotfile.file_size == new_file_size
+    if embedded_file_size_max is None or new_file_size <= embedded_file_size_max:
+        assert snapshotfile.hexdigest == ""
+        assert snapshotfile.content_b64 == base64.b64encode(new_contents).decode()
+    elif new_file_size > embedded_file_size_max:
+        assert snapshotfile.hexdigest == hash_hexdigest_readable(BytesIO(new_contents))
+        assert snapshotfile.content_b64 is None
+    assert (dst / path).read_bytes() == new_contents
+    st = (dst / path).stat()
+    assert snapshotfile.mtime_ns == st.st_mtime_ns
+    assert snapshotfile.file_size == st.st_size
 
 
-def assert_released(hexdigest: str, dst_path: Path, snapshotter: Snapshotter):
-    assert not dst_path.exists()
-    assert hexdigest in snapshotter.hexdigest_to_snapshotfiles
-    assert Path(dst_path.name) in snapshotter.relative_path_to_snapshotfile
+@pytest.mark.parametrize("snapshot_cls", [MemorySnapshot, SQLiteSnapshot])
+@pytest.mark.parametrize("src_is_dst", [True, False])
+@pytest.mark.parametrize("path", [Path("abc123"), Path("folder") / "abc123"])
+def test_snapshotter_removes_removed_file(
+    snapshot_cls: type[Snapshot], src: Path, dst: Path, db: Path, src_is_dst: bool, path: Path
+) -> None:
+    if src_is_dst:
+        dst = src
+    create_files_at_path(src, [(path, b"abc123")])
+    snapshot, snapshotter = build_snapshot_and_snapshotter(src, dst, db, snapshot_cls, [SnapshotGroup("**")])
+    snapshotter.perform_snapshot(progress=Progress())
+    assert len(snapshot) == 1
+    assert snapshot.get_file(path) is not None
+    (src / path).unlink()
+    snapshotter.perform_snapshot(progress=Progress())
+    assert len(snapshot) == 0
+    assert snapshot.get_file(path) is None
+    assert not (dst / path).exists()
 
 
-def test_snapshotter_release_hash_unlinks_files_but_keeps_metadata(tmp_path: Path) -> None:
-    src = tmp_path / "src"
-    dst = tmp_path / "dst"
-    src.mkdir()
-    dst.mkdir()
-    (src / "keep_this").write_text("this will be kept")
-    kept_digest = hash_hexdigest_readable((src / "keep_this").open(mode="rb"))
-    (src / "release_this").write_text("this will be released")
-    released_digest = hash_hexdigest_readable((src / "release_this").open(mode="rb"))
-    snapshotter = Snapshotter(src=src, dst=dst, groups=[SnapshotGroup(root_glob="*", embedded_file_size_max=0)], parallel=1)
-
-    with snapshotter.lock:
-        snapshotter.snapshot(progress=Progress())
-        assert_kept(kept_digest, dst / "keep_this", snapshotter)
-        assert_kept(released_digest, dst / "release_this", snapshotter)
-
-        snapshotter.release(released_digest)
-        assert_kept(kept_digest, dst / "keep_this", snapshotter)
-        assert_released(released_digest, dst / "release_this", snapshotter)
-
-        # re-snapshotting should restore the link
-        (src / "add_this").write_text("this is added for the next snapshot")
-        added_digest = hash_hexdigest_readable((src / "add_this").open(mode="rb"))
-        snapshotter.snapshot(progress=Progress())
-        assert_kept(kept_digest, dst / "keep_this", snapshotter)
-        assert_kept(released_digest, dst / "release_this", snapshotter)
-        assert_kept(added_digest, dst / "add_this", snapshotter)
+@pytest.mark.parametrize("snapshot_cls", [MemorySnapshot, SQLiteSnapshot])
+def test_snapshotter_release_hash_unlinks_files_but_keeps_metadata(
+    snapshot_cls: type[Snapshot], src: Path, dst: Path, db: Path
+) -> None:
+    keep = Path("keep_this")
+    release = Path("release_this")
+    create_files_at_path(src, [(keep, b"this will be kept")])
+    create_files_at_path(dst, [(keep, b"this will be kept")])
+    create_files_at_path(src, [(release, b"this will be released")])
+    create_files_at_path(dst, [(release, b"this will be released")])
+    groups = [SnapshotGroup(root_glob="**", embedded_file_size_max=0)]
+    snapshot, snapshotter = build_snapshot_and_snapshotter(src, dst, db, snapshot_cls, groups)
+    snapshotter.perform_snapshot(progress=Progress())
+    to_release = snapshot.get_file(release)
+    assert (dst / release).exists()
+    assert to_release is not None
+    snapshotter.release([to_release.hexdigest], progress=Progress())
+    assert not (dst / release).exists()
+    assert (dst / keep).exists()
+    assert snapshot.get_file(release) is not None


### PR DESCRIPTION
DO NOT MERGE still testing with aiven-core.

# Context

Astacus can currently take up reasonable amount of ram if there are many files, especially when performing a snapshot.  This can eat into available ram for the database itself.

# Changes

Split `Snapshotter` into 2 classes.  `Snapshot` responsible for holding all the data about a snapshot on disk, and `Snapshotter`, responsible for updating the snapshot to the current state.

Makes these classes generic and with 2 implementations, one holding all files in memory (equivalent to how Snapshotter currently works on master) and 1 with files stored on disk via SQLite.  The SQLite version uses constant memory and is not any slower in my benchmarks (in fact it may be a little faster).  You can look at this branch for benchmarks https://github.com/Aiven-Open/astacus/compare/joelynch/bench.

