### PR TITLE
tests: add type checking and fix type bugs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
     rev: v1.0.0
     hooks:
       - id: mypy
-        exclude: ^setup.py|^tests/|^vendor/|^astacus/proto/
+        exclude: ^setup.py|^vendor/|^astacus/proto/
         additional_dependencies:
           - types-PyYAML>=6.0.12.2
           - types-requests>=2.28.11.5

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,10 @@ yapf: black
 black:
 	pre-commit run black --all-files
 
+.PHONY: mypy
+mypy:
+	pre-commit run mypy --all-files
+
 .PHONY: reformat
 reformat: isort black
 

--- a/astacus/common/cassandra/schema.py
+++ b/astacus/common/cassandra/schema.py
@@ -10,7 +10,7 @@ from .client import CassandraSession
 from .utils import is_system_keyspace
 from astacus.common.utils import AstacusModel
 from cassandra import metadata as cm
-from typing import Any, Dict, Iterator, List, Set
+from typing import Any, Dict, Iterator, List, Mapping, Set
 
 import hashlib
 import itertools
@@ -236,7 +236,7 @@ def _extract_dcs(metadata: cm.KeyspaceMetadata) -> Dict[str, str]:
 
 
 class CassandraKeyspace(CassandraNamed):
-    network_topology_strategy_dcs: Dict[str, str]  # not [str, int] because of transient replication
+    network_topology_strategy_dcs: Mapping[str, str]  # not [str, int] because of transient replication
     durable_writes: bool
 
     aggregates: List[CassandraAggregate]

--- a/astacus/coordinator/plugins/clickhouse/steps.py
+++ b/astacus/coordinator/plugins/clickhouse/steps.py
@@ -151,7 +151,7 @@ class RetrieveDatabasesAndTablesStep(Step[DatabasesAndTables]):
     node), and relies on that to query only the first server of the cluster.
     """
 
-    clients: List[ClickHouseClient]
+    clients: Sequence[ClickHouseClient]
 
     async def run_step(self, cluster: Cluster, context: StepsContext) -> DatabasesAndTables:
         clickhouse_client = self.clients[0]
@@ -279,7 +279,7 @@ class RemoveFrozenTablesStep(Step[None]):
     When the system unfreeze flag is enabled, clears frozen parts from all disks in a single go.
     """
 
-    clients: List[ClickHouseClient]
+    clients: Sequence[ClickHouseClient]
     freeze_name: str
     unfreeze_timeout: float
 
@@ -293,7 +293,7 @@ class RemoveFrozenTablesStep(Step[None]):
 
 @dataclasses.dataclass
 class FreezeUnfreezeTablesStepBase(Step[None]):
-    clients: List[ClickHouseClient]
+    clients: Sequence[ClickHouseClient]
     freeze_name: str
     freeze_unfreeze_timeout: float
 
@@ -429,7 +429,7 @@ class RestoreReplicatedDatabasesStep(Step[None]):
     After this step, all tables will be empty.
     """
 
-    clients: List[ClickHouseClient]
+    clients: Sequence[ClickHouseClient]
     replicated_databases_zookeeper_path: str
     replicated_database_settings: ReplicatedDatabaseSettings
     drop_databases_timeout: float
@@ -615,7 +615,7 @@ class RestoreReplicaStep(Step[None]):
     """
 
     zookeeper_client: ZooKeeperClient
-    clients: List[ClickHouseClient]
+    clients: Sequence[ClickHouseClient]
     disks: Disks
     restart_timeout: float
     max_concurrent_restart_per_node: int
@@ -699,7 +699,7 @@ class AttachMergeTreePartsStep(Step[None]):
     details.
     """
 
-    clients: List[ClickHouseClient]
+    clients: Sequence[ClickHouseClient]
     disks: Disks
     attach_timeout: float
     max_concurrent_attach_per_node: int
@@ -735,7 +735,7 @@ class SyncTableReplicasStep(Step[None]):
     are all exchanged between all nodes.
     """
 
-    clients: List[ClickHouseClient]
+    clients: Sequence[ClickHouseClient]
     sync_timeout: float
     max_concurrent_sync_per_node: int
 

--- a/tests/integration/coordinator/plugins/clickhouse/conftest.py
+++ b/tests/integration/coordinator/plugins/clickhouse/conftest.py
@@ -38,6 +38,7 @@ import logging
 import pytest
 import rohmu
 import secrets
+import subprocess
 import sys
 import tempfile
 import urllib.parse
@@ -126,7 +127,7 @@ class MinioBucket:
 
 @dataclasses.dataclass(frozen=True)
 class MinioService:
-    process: asyncio.subprocess.Process
+    process: subprocess.Popen[bytes]
     data_dir: Path
     host: str
     server_port: int
@@ -217,7 +218,15 @@ async def create_minio_service(ports: Ports) -> AsyncIterator[MinioService]:
             "MINIO_ROOT_USER": root_user,
             "MINIO_ROOT_PASSWORD": root_password,
         }
-        command = ["/usr/bin/minio", "server", data_dir, "--address", server_netloc, "--console-address", console_netloc]
+        command: List[Union[str, Path]] = [
+            "/usr/bin/minio",
+            "server",
+            data_dir,
+            "--address",
+            server_netloc,
+            "--console-address",
+            console_netloc,
+        ]
         async with run_process_and_wait_for_pattern(
             args=command,
             cwd=data_dir,

--- a/tests/integration/coordinator/plugins/clickhouse/test_client.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_client.py
@@ -5,6 +5,7 @@ See LICENSE for details
 from .conftest import ClickHouseCommand, create_clickhouse_service, get_clickhouse_client
 from astacus.coordinator.plugins.clickhouse.client import ClickHouseClientQueryError
 from tests.integration.conftest import Ports, Service
+from typing import cast, Sequence
 
 import pytest
 import time
@@ -18,7 +19,7 @@ pytestmark = [
 @pytest.mark.asyncio
 async def test_client_execute(clickhouse: Service) -> None:
     client = get_clickhouse_client(clickhouse)
-    response = await client.execute(b"SHOW DATABASES")
+    response = cast(Sequence[list[str]], await client.execute(b"SHOW DATABASES"))
     assert sorted(list(response)) == [["INFORMATION_SCHEMA"], ["default"], ["information_schema"], ["system"]]
 
 

--- a/tests/integration/coordinator/plugins/clickhouse/test_plugin.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_plugin.py
@@ -278,7 +278,7 @@ async def test_restores_table_with_nested_fields(restored_cluster: List[ClickHou
     assert response == [[123, [4], [5]]]
 
 
-async def check_object_storage_data(cluster: List[ClickHouseClient]) -> None:
+async def check_object_storage_data(cluster: Sequence[ClickHouseClient]) -> None:
     s1_data = [[123, "foo"], [456, "bar"]]
     s2_data = [[789, "baz"]]
     cluster_data = [s1_data, s1_data, s2_data]

--- a/tests/integration/coordinator/plugins/flink/test_steps.py
+++ b/tests/integration/coordinator/plugins/flink/test_steps.py
@@ -6,6 +6,7 @@ from astacus.coordinator.plugins.base import StepsContext
 from astacus.coordinator.plugins.flink.manifest import FlinkManifest
 from astacus.coordinator.plugins.flink.steps import FlinkManifestStep, RestoreDataStep, RetrieveDataStep
 from astacus.coordinator.plugins.zookeeper import KazooZooKeeperClient
+from unittest.mock import Mock
 from uuid import uuid4
 
 import pytest
@@ -35,6 +36,6 @@ async def test_restore_data(zookeeper_client: KazooZooKeeperClient):
     manifest = FlinkManifest(data=data)
     context = StepsContext()
     context.set_result(FlinkManifestStep, manifest)
-    await RestoreDataStep(zookeeper_client, ["catalog", "flink"]).run_step(cluster=None, context=context)
-    res = await RetrieveDataStep(zookeeper_client, ["catalog", "flink"]).run_step(cluster=None, context=None)
+    await RestoreDataStep(zookeeper_client, ["catalog", "flink"]).run_step(cluster=Mock(), context=context)
+    res = await RetrieveDataStep(zookeeper_client, ["catalog", "flink"]).run_step(cluster=Mock(), context=Mock())
     assert res == data

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -188,4 +188,5 @@ def astacus_run(
 
 
 def astacus_ls(astacus: TestNode) -> List[str]:
+    assert astacus.root_path
     return sorted(str(x.relative_to(astacus.root_path)) for x in astacus.root_path.glob("**/*"))

--- a/tests/system/test_config_reload.py
+++ b/tests/system/test_config_reload.py
@@ -27,6 +27,7 @@ def test_reload_config(tmpdir, rootdir: str, astacus1: TestNode, astacus2: TestN
     check_without_status = astacus_run(rootdir, astacus1, "check-reload", check=True, capture_output=True)
     assert check_without_status.returncode == 0
     assert "Configuration does not need to be reloaded" in check_without_status.stdout.decode()
+    assert astacus1.root_path
     # Write some data to backup, including files that don't match the reloaded glob
     (astacus1.root_path / "saved.foo").write_text("dont_care")
     (astacus1.root_path / "ignored.bar").write_text("dont_care")

--- a/tests/unit/common/cassandra/test_client.py
+++ b/tests/unit/common/cassandra/test_client.py
@@ -4,12 +4,13 @@ See LICENSE for details
 """
 
 from astacus.common.cassandra.config import CassandraClientConfiguration
+from pytest_mock import MockFixture
 
 import astacus.common.cassandra.client as client_module
 import pytest
 
 
-def test_cassandra_session(mocker):
+def test_cassandra_session(mocker: MockFixture) -> None:
     ccluster = mocker.MagicMock()
     csession = mocker.MagicMock()
     session = client_module.CassandraSession(cluster=ccluster, session=csession)
@@ -32,7 +33,7 @@ second!;
     assert len(csession.execute.mock_calls) == 2
 
 
-def create_client(mocker, ssl=False):
+def create_client(mocker: MockFixture, ssl: bool = False) -> client_module.CassandraClient:
     mocker.patch.object(client_module, "Cluster")
     mocker.patch.object(client_module, "WhiteListRoundRobinPolicy")
 
@@ -47,14 +48,14 @@ def create_client(mocker, ssl=False):
 
 
 @pytest.mark.parametrize("ssl", [False, True])
-def test_cassandra_client(mocker, ssl):
+def test_cassandra_client(mocker: MockFixture, ssl: bool) -> None:
     client: client_module.CassandraClient = create_client(mocker, ssl=ssl)
     with client.connect() as session:
         assert isinstance(session, client_module.CassandraSession)
 
 
 @pytest.mark.asyncio
-async def test_cassandra_client_run(mocker):
+async def test_cassandra_client_run(mocker: MockFixture):
     client = create_client(mocker)
 
     def test_fun(cas):

--- a/tests/unit/common/test_op.py
+++ b/tests/unit/common/test_op.py
@@ -7,6 +7,7 @@ astacus.common.op tests that do not fit elsewhere
 
 """
 from astacus.common import op
+from astacus.common.exceptions import ExpiredOperationException
 from astacus.common.statsd import StatsClient
 from starlette.background import BackgroundTasks
 from starlette.datastructures import URL
@@ -35,7 +36,7 @@ class MockOp:
         (None, op.Op.Status.done, None),
         # If operation throws ExpiredOperationException, op status
         # should stay running as it may point to the next operation
-        (op.ExpiredOperationException, op.Op.Status.running, None),
+        (ExpiredOperationException, op.Op.Status.running, None),
         # If operation throws 'something else', it should fail the op status
         (AssertionError, op.Op.Status.fail, AssertionError),
     ],

--- a/tests/unit/common/test_storage.py
+++ b/tests/unit/common/test_storage.py
@@ -11,7 +11,7 @@ TBD: Test with something else than local files?
 from astacus.common import exceptions
 from astacus.common.cachingjsonstorage import CachingJsonStorage
 from astacus.common.rohmustorage import RohmuConfig, RohmuStorage
-from astacus.common.storage import FileStorage, JsonStorage
+from astacus.common.storage import FileStorage, Json, JsonStorage
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
 from rohmu.object_storage import google
@@ -24,7 +24,7 @@ TEST_HEXDIGEST = "deadbeef"
 TEXT_HEXDIGEST_DATA = b"data" * 15
 
 TEST_JSON = "jsonblob"
-TEST_JSON_DATA = {"foo": 7, "array": [1, 2, 3], "true": True}
+TEST_JSON_DATA: Json = {"foo": 7, "array": [1, 2, 3], "true": True}
 
 
 def create_storage(*, tmpdir, engine, **kw):

--- a/tests/unit/coordinator/plugins/cassandra/test_backup_steps.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_backup_steps.py
@@ -30,7 +30,7 @@ class RetrieveTestCase:
     duplicate_address: bool = False
 
     # Output
-    expected_error: Optional[Exception] = None
+    expected_error: Optional[type[Exception]] = None
 
     def __str__(self):
         return self.name

--- a/tests/unit/coordinator/plugins/cassandra/test_plugin.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_plugin.py
@@ -7,7 +7,7 @@ from astacus.common import ipc
 from astacus.coordinator.plugins.base import StepFailedError
 from astacus.coordinator.plugins.cassandra import plugin
 from astacus.coordinator.plugins.cassandra.model import CassandraConfigurationNode
-from tests.unit.node.test_node_cassandra import CassandraTestConfig
+from tests.unit.conftest import CassandraTestConfig
 from types import SimpleNamespace
 
 import pytest

--- a/tests/unit/coordinator/plugins/clickhouse/test_config.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_config.py
@@ -3,16 +3,16 @@ Copyright (c) 2021 Aiven Ltd
 See LICENSE for details
 """
 from astacus.coordinator.plugins.clickhouse.client import HttpClickHouseClient
-from astacus.coordinator.plugins.clickhouse.config import ClickHouseConfiguration, ClickHouseNode
-from astacus.coordinator.plugins.clickhouse.plugin import get_clickhouse_clients, get_zookeeper_client
-from astacus.coordinator.plugins.zookeeper import KazooZooKeeperClient, KazooZooKeeperConnection
+from astacus.coordinator.plugins.clickhouse.config import ClickHouseConfiguration, ClickHouseNode, get_clickhouse_clients
+from astacus.coordinator.plugins.zookeeper import KazooZooKeeperClient, KazooZooKeeperConnection, ZooKeeperUser
 from astacus.coordinator.plugins.zookeeper_config import (
+    get_zookeeper_client,
     ZooKeeperConfiguration,
     ZooKeeperConfigurationUser,
     ZooKeeperNode,
-    ZooKeeperUser,
 )
 from kazoo.client import KazooClient
+from pydantic import SecretStr
 from typing import cast, List
 
 import pytest
@@ -31,7 +31,7 @@ def test_get_zookeeper_client() -> None:
 def test_get_authenticated_zookeeper_client() -> None:
     configuration = ZooKeeperConfiguration(
         nodes=[ZooKeeperNode(host="::1", port=5556)],
-        user=ZooKeeperConfigurationUser(username="local-user", password="secret"),
+        user=ZooKeeperConfigurationUser(username="local-user", password=SecretStr("secret")),
     )
     client = get_zookeeper_client(configuration)
     assert client is not None and isinstance(client, KazooZooKeeperClient)

--- a/tests/unit/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_steps.py
@@ -246,7 +246,7 @@ async def test_retrieve_access_entities_fails_from_concurrent_updates() -> None:
 
 @pytest.mark.asyncio
 async def test_retrieve_tables() -> None:
-    clients = [StubClickHouseClient(), StubClickHouseClient()]
+    clients: Sequence[StubClickHouseClient] = [StubClickHouseClient(), StubClickHouseClient()]
     clients[0].set_response(
         TABLES_LIST_QUERY,
         [
@@ -319,6 +319,7 @@ async def test_retrieve_tables() -> None:
             ]
         ],
     )
+
     step = RetrieveDatabasesAndTablesStep(clients=clients)
     context = StepsContext()
     databases, tables = await step.run_step(Cluster(nodes=[]), context)

--- a/tests/unit/coordinator/plugins/test_base.py
+++ b/tests/unit/coordinator/plugins/test_base.py
@@ -240,6 +240,7 @@ async def test_upload_manifest_step_generates_correct_backup_name(
     async_json_storage = AsyncJsonStorage(storage=MemoryJsonStorage(items={}))
     step = UploadManifestStep(json_storage=async_json_storage, plugin=ipc.Plugin.files)
     await step.run_step(cluster=single_node_cluster, context=context)
+    assert isinstance(async_json_storage.storage, MemoryJsonStorage)
     assert "backup-2020-01-07T05:00:00+00:00" in async_json_storage.storage.items
 
 

--- a/tests/unit/coordinator/test_backup.py
+++ b/tests/unit/coordinator/test_backup.py
@@ -8,6 +8,7 @@ Test that the coordinator backup endpoint works.
 
 from astacus.common import ipc, utils
 from astacus.common.ipc import SnapshotHash
+from astacus.common.progress import Progress
 from astacus.common.statsd import StatsClient
 from astacus.coordinator.api import OpName
 from astacus.coordinator.plugins.base import build_node_index_datas, NodeIndexData
@@ -92,7 +93,7 @@ def test_backup(fail_at, app, client, storage):
         assert app.state.coordinator_state.op_info.op_id == 1
 
 
-_progress_done = ipc.Progress(final=True)
+_progress_done = Progress(final=True)
 
 
 def _ssresults(*kwarg_list):

--- a/tests/unit/coordinator/test_list.py
+++ b/tests/unit/coordinator/test_list.py
@@ -238,7 +238,7 @@ def test_api_list_deduplication(backup_manifest: BackupManifest, tmpdir: PathLik
                         name="1",
                         start=datetime.datetime(2020, 1, 2, 3, 4, 5, 678, tzinfo=datetime.timezone.utc),
                         end=datetime.datetime(2020, 1, 2, 5, 6, 7, 891, tzinfo=datetime.timezone.utc),
-                        plugin="clickhouse",
+                        plugin=Plugin("clickhouse"),
                         attempt=1,
                         nodes=2,
                         cluster_files=6,

--- a/tests/unit/coordinator/test_restore.py
+++ b/tests/unit/coordinator/test_restore.py
@@ -11,6 +11,7 @@ from astacus.coordinator.config import CoordinatorNode
 from astacus.coordinator.plugins.base import get_node_to_backup_index
 from contextlib import nullcontext as does_not_raise
 from dataclasses import dataclass
+from datetime import datetime, UTC
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -23,8 +24,8 @@ import respx
 BACKUP_NAME = "dummybackup"
 
 BACKUP_MANIFEST = ipc.BackupManifest(
-    start="2020-01-01 21:43:00Z",
-    end="2020-02-02 12:34:56Z",
+    start=datetime(2020, 1, 1, 21, 43, tzinfo=UTC),
+    end=datetime(2020, 2, 2, 12, 34, 56, tzinfo=UTC),
     attempt=1,
     snapshot_results=[
         ipc.SnapshotResult(

--- a/tests/unit/node/conftest.py
+++ b/tests/unit/node/conftest.py
@@ -5,10 +5,11 @@ See LICENSE for details
 
 from astacus.common import magic
 from astacus.common.progress import Progress
+from astacus.common.snapshot import SnapshotGroup
 from astacus.common.storage import FileStorage
 from astacus.node.api import router as node_router
 from astacus.node.config import NodeConfig
-from astacus.node.snapshotter import SnapshotGroup, Snapshotter
+from astacus.node.snapshotter import Snapshotter
 from astacus.node.uploader import Uploader
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -47,12 +48,12 @@ def fixture_app(tmpdir) -> FastAPI:
             },
         }
     )
-    yield app
+    return app
 
 
 @pytest.fixture(name="client")
 def fixture_client(app) -> TestClient:
-    yield TestClient(app)
+    return TestClient(app)
 
 
 class SnapshotterWithDefaults(Snapshotter):
@@ -74,16 +75,16 @@ def fixture_snapshotter(tmpdir):
     src.mkdir()
     dst = Path(tmpdir) / "dst"
     dst.mkdir()
-    yield SnapshotterWithDefaults(src=src, dst=dst, groups=[SnapshotGroup(root_glob="*")], parallel=1)
+    return SnapshotterWithDefaults(src=src, dst=dst, groups=[SnapshotGroup(root_glob="*")], parallel=1)
 
 
 @pytest.fixture(name="uploader")
 def fixture_uploader(storage):
-    yield Uploader(storage=storage)
+    return Uploader(storage=storage)
 
 
 @pytest.fixture(name="storage")
 def fixture_storage(tmpdir):
     storage_path = Path(tmpdir) / "storage"
     storage_path.mkdir()
-    yield FileStorage(storage_path)
+    return FileStorage(storage_path)

--- a/tests/unit/node/test_node_cassandra.py
+++ b/tests/unit/node/test_node_cassandra.py
@@ -149,7 +149,7 @@ def test_api_cassandra_get_schema_hash(ctenv, fail, mocker, astacus_node_cassand
 
 class TestCassandraRestoreSSTables:
     @pytest.fixture(name="make_sstables_request")
-    def fixture_make_sstables_request(self, astacus_node_cassandra) -> ipc.CassandraRestoreSSTablesRequest:
+    def fixture_make_sstables_request(self, astacus_node_cassandra) -> type[ipc.CassandraRestoreSSTablesRequest]:
         class DefaultedRestoreSSTablesRequest(ipc.CassandraRestoreSSTablesRequest):
             table_glob: str = astacus_node_cassandra.SNAPSHOT_GLOB
             keyspaces_to_skip: Sequence[str] = list(SYSTEM_KEYSPACES)

--- a/tests/unit/node/test_node_download.py
+++ b/tests/unit/node/test_node_download.py
@@ -5,8 +5,9 @@ See LICENSE for details
 
 from astacus.common import ipc, utils
 from astacus.common.progress import Progress
+from astacus.common.snapshot import SnapshotGroup
 from astacus.node.download import Downloader
-from astacus.node.snapshotter import SnapshotGroup, Snapshotter
+from astacus.node.snapshotter import Snapshotter
 from pathlib import Path
 
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -44,17 +44,19 @@ def test_reload_config_sleep_and_http_timeout_honors_total_wait_completion() -> 
             current_time.tick(delta=datetime.timedelta(seconds=duration))
 
         with mock.patch.object(time, "sleep", new=sleep):
-
+            # mypy wants a return for this function but pylint doesn't
+            # pylint: disable=useless-return
             def http_request(*args, timeout: float = 10, **kwargs) -> Mapping[str, Any] | None:
                 time_since_start = time.monotonic() - start_time
                 assert time_since_start + timeout <= wait_completion_secs, "request could end after completion"
+                return None
 
             with mock.patch.object(astacus.client, "http_request", new=http_request):
                 _reload_config(ClientArgs(wait_completion=wait_completion_secs, url="http://localhost:55123"))
 
 
 def test_reload_config_stops_retrying_on_success() -> None:
-    return_values = [None, None, {}]
+    return_values: list[Mapping[str, Any] | None] = [None, None, {}]
     with mock.patch.object(time, "sleep"):
 
         def http_request(*args, **kwargs) -> Mapping[str, Any] | None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,7 @@ See LICENSE for details
 """
 from astacus.common.rohmustorage import RohmuConfig
 from pathlib import Path
-from typing import List, Sequence, Union
+from typing import List, Union
 
 import importlib
 import re
@@ -74,15 +74,15 @@ def create_rohmu_config(tmpdir, *, compression=True, encryption=True) -> RohmuCo
     return RohmuConfig.parse_obj(config)
 
 
-def parse_clickhouse_version(command_output: bytes) -> Sequence[int]:
+def parse_clickhouse_version(command_output: bytes) -> tuple[int, ...]:
     version_match = re.search(r"([\d.]+\d)", command_output.decode())
     if not version_match:
-        raise ValueError(f"Unable to parse version from command output: {command_output}")
+        raise ValueError(f"Unable to parse version from command output: {command_output.decode()}")
     version_tuple = tuple(int(part) for part in version_match.group(0).split(".") if part)
     return version_tuple
 
 
-def get_clickhouse_version(command: List[Union[str, Path]]) -> Sequence[int]:
+def get_clickhouse_version(command: List[Union[str, Path]]) -> tuple[int, ...]:
     version_command_output = subprocess.check_output([*command, "--version"])
     return parse_clickhouse_version(version_command_output)
 


### PR DESCRIPTION
You can still opt out of type checking by not typing a function.  But if types are specified, we should check that they are correct (according to mypy).  This makes it easier to run mypy on new code in `tests` to check that it is correct without having a lot of preexisting errors appear.