### PR TITLE
tests: Add combined coverage handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,14 +55,17 @@ copyright:
 	$(eval MISSING_COPYRIGHT := $(shell git ls-files "*.py" | grep -v __init__.py | xargs grep -EL "Copyright \(c\) 20.* Aiven|Aiven license OK"))
 	@if [ "$(MISSING_COPYRIGHT)" != "" ]; then echo Missing Copyright statement in files: $(MISSING_COPYRIGHT) ; false; fi
 
+# Normal 'coverage run' sets COVERAGE_RUN; we do the same here
+# explicitly to be able to detect if we want to gather coverage, or not.
+#
+# pytest-cov is not parallel-mode-aware, so pretend its result was just one of many.
 .PHONY: unittest
 unittest: $(GENERATED)
-	rm -rf htmlcov
-	python3 -m pytest --cov=./ \
-		--cov-report=html \
-		--cov-report term-missing \
-		--cov-report xml:coverage.xml \
-		-s -vvv -x tests/
+	coverage erase
+	COVERAGE_RUN=1 \
+		python3 -m pytest --cov=./ --cov-append -s -vvv -x tests/
+	mv .coverage .coverage.root
+	coverage combine
 
 .PHONY: test
 test: lint copyright unittest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,15 @@ combine_as_imports = true
 profile = "black"
 skip_gitignore = true
 line_length = 125
+
+[tool.coverage.run]
+# Gather statistics per invocation
+parallel = true
+
+# We're only interested about Astacus core, not rohmu/..
+#
+# (tests is listed here mostly so that we can detect unused utility functions in them)
+source = [
+     "astacus",
+     "tests"
+]

--- a/requirements.testing.txt
+++ b/requirements.testing.txt
@@ -14,11 +14,15 @@ pytest==6.2.5
 
 # pinning mypy to the same version as pre-commit
 mypy==1.0.0
+
 # types for things that don't seem to have them
 types-PyYAML>=6.0.12.2
 types-tabulate>=0.9.0.0
 types-urllib3>=1.26.25.4
 typing_extensions>=4.7.1
+
+# F38
+coverage==7.0.5
 
 freezegun>=1.2
 respx==0.20.1

--- a/tests/integration/coordinator/plugins/clickhouse/conftest.py
+++ b/tests/integration/coordinator/plugins/clickhouse/conftest.py
@@ -25,7 +25,12 @@ from pathlib import Path
 from tests.conftest import CLICKHOUSE_PATH_OPTION, CLICKHOUSE_RESTORE_PATH_OPTION
 from tests.integration.conftest import get_command_path, Ports, run_process_and_wait_for_pattern, Service, ServiceCluster
 from tests.system.conftest import background_process, wait_url_up
-from tests.utils import CONSTANT_TEST_RSA_PRIVATE_KEY, CONSTANT_TEST_RSA_PUBLIC_KEY, get_clickhouse_version
+from tests.utils import (
+    CONSTANT_TEST_RSA_PRIVATE_KEY,
+    CONSTANT_TEST_RSA_PUBLIC_KEY,
+    format_astacus_command,
+    get_clickhouse_version,
+)
 from typing import AsyncIterator, Awaitable, Iterator, List, Optional, Sequence, Union
 
 import argparse
@@ -39,7 +44,6 @@ import pytest
 import rohmu
 import secrets
 import subprocess
-import sys
 import tempfile
 import urllib.parse
 
@@ -444,7 +448,7 @@ async def _astacus(*, config: GlobalConfig) -> AsyncIterator[Service]:
     assert config.object_storage is not None
     config_path = Path(config.object_storage.temporary_directory) / f"astacus_{config.uvicorn.port}.json"
     config_path.write_text(config.json())
-    cmd = [sys.executable, "-m", "astacus.main", "server", "-c", str(config_path)]
+    cmd = format_astacus_command("server", "-c", str(config_path))
     async with background_process(*cmd, env={"PYTHONPATH": astacus_source_root}) as process:
         await wait_url_up(f"http://localhost:{config.uvicorn.port}")
         storage = config.object_storage.storages[config.object_storage.default_storage]

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -6,7 +6,7 @@ from astacus.common.utils import AstacusModel, exponential_backoff
 from contextlib import asynccontextmanager
 from httpx import URL
 from pathlib import Path
-from tests.utils import create_rohmu_config
+from tests.utils import create_rohmu_config, format_astacus_command
 from types import MappingProxyType
 from typing import Any, AsyncIterator, List, Mapping, Optional, Union
 
@@ -17,7 +17,6 @@ import logging
 import os.path
 import pytest
 import subprocess
-import sys
 
 logger = logging.getLogger(__name__)
 
@@ -139,14 +138,7 @@ async def _astacus(*, tmpdir, index: int) -> AsyncIterator[TestNode]:
     node = ASTACUS_NODES[index]
     a_conf_path = create_astacus_config(tmpdir=tmpdir, node=node)
     astacus_source_root = os.path.join(os.path.dirname(__file__), "..", "..")
-
-    # simulate this (for some reason, in podman the 'astacus' command
-    # is not to be found, I suppose the package hasn't been
-    # initialized)
-    #
-    # cmd = ["astacus", "server", "-c", str(a_conf_path)]
-    cmd = [sys.executable, "-m", "astacus.main", "server", "-c", str(a_conf_path)]
-
+    cmd = format_astacus_command("server", "-c", str(a_conf_path))
     async with background_process(*cmd, env={"PYTHONPATH": astacus_source_root}) as process:
         await wait_url_up(node.url)
         yield node
@@ -178,12 +170,7 @@ def astacus_run(
     check: bool = True,
     capture_output: bool = False,
 ) -> subprocess.CompletedProcess:
-    # simulate this (for some reason, in podman the 'astacus' command
-    # is not to be found, I suppose the package hasn't been
-    # initialized)
-    #
-    # cmd = ["astacus", "--url", astacus.url, "-w", "10"]
-    cmd = [sys.executable, "-m", "astacus.main", "--url", astacus.url, "-w", "10"]
+    cmd = format_astacus_command("--url", astacus.url, "-w", "10")
     return subprocess.run(cmd + list(args), check=check, capture_output=capture_output, env={"PYTHONPATH": rootdir})
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,8 +7,10 @@ from pathlib import Path
 from typing import List, Union
 
 import importlib
+import os
 import re
 import subprocess
+import sys
 
 # These test keys are from copied from pghoard
 
@@ -89,3 +91,10 @@ def get_clickhouse_version(command: List[Union[str, Path]]) -> tuple[int, ...]:
 
 def is_cassandra_driver_importable() -> bool:
     return importlib.util.find_spec("cassandra") is not None
+
+
+def format_astacus_command(*arg: str) -> List[str]:
+    # If we're gathering coverage, run subprocesses under coverage run
+    if os.environ.get("COVERAGE_RUN", None):
+        return [sys.executable, "-m", "coverage", "run", "-m", "astacus.main"] + list(arg)
+    return [sys.executable, "-m", "astacus.main"] + list(arg)


### PR DESCRIPTION
This slows invoked subprocesses by ~30% (or less, if they do heavy computation) which is hopefully acceptable cost. We already did gather coverage on the main pytest process.

I wonder if this breaks codecov or if it is somehow broken anyway - https://app.codecov.io/gh/Aiven-Open/astacus/pull/165 shows this as in 'processing' state for half an hour now. Perhaps we're not classified as open source plan and are hitting some limit? Or different coverage invocation makes it unable to find the parent commit (it has coverage % which is higher than what is in `main`).