### PR TITLE
clickhouse: fix missing lenient custom setting

### DIFF
--- a/astacus/coordinator/plugins/clickhouse/steps.py
+++ b/astacus/coordinator/plugins/clickhouse/steps.py
@@ -510,6 +510,7 @@ class RestoreReplicatedDatabasesStep(Step[None]):
             # for tables not needing them.
             b"SET allow_experimental_geo_types=true",
             b"SET allow_experimental_object_type=true",
+            b"SET allow_suspicious_codecs=true",
             b"SET allow_suspicious_low_cardinality_types=true",
             # If a table was created with flatten_nested=0, we must be careful to not re-create the
             # table with flatten_nested=1, since this would recreate the table with a different schema.

--- a/tests/unit/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_steps.py
@@ -796,6 +796,7 @@ async def test_creates_all_replicated_databases_and_tables_in_manifest() -> None
         b" ENGINE = Replicated('/clickhouse/databases/db%2Dtwo', '{my_shard}', '{my_replica}')",
         b"SET allow_experimental_geo_types=true",
         b"SET allow_experimental_object_type=true",
+        b"SET allow_suspicious_codecs=true",
         b"SET allow_suspicious_low_cardinality_types=true",
         b"SET flatten_nested=0",
         b"CREATE TABLE db-one.table-uno ...",
@@ -853,6 +854,7 @@ async def test_creates_all_replicated_databases_and_tables_in_manifest_with_cust
         b"SETTINGS cluster_username='alice', cluster_password='alice_secret'",
         b"SET allow_experimental_geo_types=true",
         b"SET allow_experimental_object_type=true",
+        b"SET allow_suspicious_codecs=true",
         b"SET allow_suspicious_low_cardinality_types=true",
         b"SET flatten_nested=0",
         b"CREATE TABLE db-one.table-uno ...",
@@ -895,6 +897,7 @@ async def test_drops_each_database_on_all_servers_before_recreating_it() -> None
     queries_expected_on_a_single_node = [
         b"SET allow_experimental_geo_types=true",
         b"SET allow_experimental_object_type=true",
+        b"SET allow_suspicious_codecs=true",
         b"SET allow_suspicious_low_cardinality_types=true",
         b"SET flatten_nested=0",
         b"CREATE TABLE db-one.table-uno ...",


### PR DESCRIPTION
`allow_suspicious_codecs` was missing from the list of settings we need to temporarily allow to recreate the table like it was before the backup.

This avoids this error:

    <Error> DynamicQueryHandler: Code: 36. DB::Exception: The
    combination of compression codecs Gorilla is meaningless, because
    it does not make sense to apply a floating-point time series codec
    to non-floating-point columns (Note: you can enable setting
    'allow_suspicious_codecs' to skip this check). (BAD_ARGUMENTS)

[DDB-778]