### PR TITLE
cleanup: Use less memory

### DIFF
--- a/astacus/common/asyncstorage.py
+++ b/astacus/common/asyncstorage.py
@@ -7,6 +7,7 @@ See LICENSE for details
 
 from astacus.common.storage import HexDigestStorage, Json, JsonStorage
 from astacus.common.utils import AstacusModel
+from pathlib import Path
 from starlette.concurrency import run_in_threadpool
 
 
@@ -44,8 +45,11 @@ class AsyncJsonStorage:
     async def delete_json(self, name: str) -> None:
         return await run_in_threadpool(self.storage.delete_json, name)
 
-    async def download_json(self, name: str) -> Json:
+    async def download_json(self, name: str) -> Path:
         return await run_in_threadpool(self.storage.download_json, name)
+
+    async def download_and_read_json(self, name: str) -> Json:
+        return await run_in_threadpool(self.storage.download_and_read_json, name)
 
     async def list_jsons(self) -> list[str]:
         return await run_in_threadpool(self.storage.list_jsons)

--- a/astacus/common/rohmustorage.py
+++ b/astacus/common/rohmustorage.py
@@ -10,6 +10,7 @@ from .storage import Json, MultiStorage, Storage, StorageUploadResult
 from .utils import AstacusModel
 from astacus.common import exceptions
 from enum import Enum
+from pathlib import Path
 from pydantic import Field
 from rohmu import errors, rohmufile
 from rohmu.compressor import CompressionStream
@@ -184,7 +185,14 @@ class RohmuStorage(Storage):
         key = os.path.join(self.json_key, name)
         self.storage.delete_key(key)
 
-    def download_json(self, name: str) -> Json:
+    def download_json(self, name: str) -> Path:
+        key = os.path.join(self.json_key, name)
+        path = Path(self.config.temporary_directory) / name
+        with path.open("wb") as f:
+            self._download_key_to_file(key, f)
+        return Path(f.name)
+
+    def download_and_read_json(self, name: str) -> Json:
         key = os.path.join(self.json_key, name)
         f = io.BytesIO()
         self._download_key_to_file(key, f)

--- a/astacus/common/storage.py
+++ b/astacus/common/storage.py
@@ -75,7 +75,11 @@ class JsonStorage(ABC):
         ...
 
     @abstractmethod
-    def download_json(self, name: str) -> Json:
+    def download_json(self, name: str) -> Path:
+        ...
+
+    @abstractmethod
+    def download_and_read_json(self, name: str) -> Json:
         ...
 
     @abstractmethod
@@ -166,8 +170,16 @@ class FileStorage(Storage):
         self._json_to_path(name).unlink()
 
     @file_error_wrapper
-    def download_json(self, name: str) -> Json:
+    def download_json(self, name: str) -> Path:
         logger.info("download_json %r", name)
+        path = self._json_to_path(name)
+        if not path.exists():
+            raise NotFoundException
+        return path
+
+    @file_error_wrapper
+    def download_and_read_json(self, name: str) -> Json:
+        logger.info("download_and_read_json %r", name)
         path = self._json_to_path(name)
         with open(path) as f:
             return json.load(f)

--- a/astacus/coordinator/list.py
+++ b/astacus/coordinator/list.py
@@ -39,7 +39,7 @@ def _iter_backups(storage: JsonStorage, backup_prefix: str) -> Iterator[ipc.List
         if not name.startswith(backup_prefix):
             continue
         pname = name[len(backup_prefix) :]
-        manifest = ipc.BackupManifest.parse_obj(storage.download_json(name))
+        manifest = ipc.BackupManifest.parse_obj(storage.download_and_read_json(name))
         files = sum(x.files for x in manifest.snapshot_results)
         total_size = sum(x.total_size for x in manifest.snapshot_results)
         upload_size = sum(x.total_size for x in manifest.upload_results)

--- a/astacus/coordinator/manifest.py
+++ b/astacus/coordinator/manifest.py
@@ -1,13 +1,97 @@
 """
-Copyright (c) 2021 Aiven Ltd
+Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
+
 from astacus.common import asyncstorage, ipc
+from pathlib import Path
 from starlette.concurrency import run_in_threadpool
+
+import datetime
+
+
+class BackupManifestFileWrapper:
+    """Wrapper for large manifest files, caches some fields but always reads in
+    whole file for `snapshot_results`.  This is needed because for the cleanup
+    step we can have up to 30 large manifests, on the order of 500Mb each,
+    so they can't all exist in memory at once.
+    """
+
+    def __init__(self, file_path: Path):
+        self._file_path = file_path
+        # filename is not set by ipc.BackupManifest
+        self.filename = file_path.name
+        self._is_cached = False
+
+        self._start: datetime.datetime | None = None
+        self._end: datetime.datetime | None = None
+        self._attempt: int | None = None
+        self._upload_results: list[ipc.SnapshotUploadResult] | None = None
+        self._plugin: str | None = None
+        self._plugin_data: dict | None = None
+
+    def _load_and_cache_data(self):
+        if not self._is_cached:
+            manifest = ipc.BackupManifest.parse_file(self._file_path)
+            self._start = manifest.start
+            self._end = manifest.end
+            self._attempt = manifest.attempt
+            self._upload_results = manifest.upload_results
+            self._plugin = manifest.plugin
+            self._plugin_data = manifest.plugin_data
+            self._is_cached = True
+
+    @property
+    def start(self) -> datetime.datetime:
+        self._load_and_cache_data()
+        assert self._start is not None
+        return self._start
+
+    @property
+    def end(self) -> datetime.datetime:
+        self._load_and_cache_data()
+        assert self._end is not None
+        return self._end
+
+    @property
+    def attempt(self) -> int:
+        self._load_and_cache_data()
+        assert self._attempt is not None
+        return self._attempt
+
+    @property
+    def upload_results(self) -> list[ipc.SnapshotUploadResult]:
+        self._load_and_cache_data()
+        assert self._upload_results is not None
+        return self._upload_results
+
+    @property
+    def plugin(self) -> str:
+        self._load_and_cache_data()
+        assert self._plugin is not None
+        return self._plugin
+
+    @property
+    def plugin_data(self) -> dict:
+        self._load_and_cache_data()
+        assert self._plugin_data is not None
+        return self._plugin_data
+
+    def snapshot_results(self) -> list[ipc.SnapshotResult]:
+        return ipc.BackupManifest.parse_file(self._file_path).snapshot_results
+
+    def delete(self) -> None:
+        return self._file_path.unlink()
+
+
+async def download_backup_manifest_file_wrapper(
+    json_storage: asyncstorage.AsyncJsonStorage, backup_name: str
+) -> BackupManifestFileWrapper:
+    return BackupManifestFileWrapper(await json_storage.download_json(backup_name))
 
 
 async def download_backup_manifest(json_storage: asyncstorage.AsyncJsonStorage, backup_name: str) -> ipc.BackupManifest:
-    d = await json_storage.download_json(backup_name)
+    d = await json_storage.download_and_read_json(backup_name)
     manifest = await run_in_threadpool(ipc.BackupManifest.parse_obj, d)
     assert not manifest.filename or manifest.filename == backup_name
     manifest.filename = backup_name

--- a/astacus/node/download.py
+++ b/astacus/node/download.py
@@ -172,7 +172,7 @@ class DownloadOp(NodeOp[ipc.SnapshotDownloadRequest, ipc.NodeResult]):
     def download(self) -> None:
         assert self.snapshotter is not None
         # Actual 'restore from backup'
-        manifest = ipc.BackupManifest.parse_obj(self.storage.download_json(self.req.backup_name))
+        manifest = ipc.BackupManifest.parse_obj(self.storage.download_and_read_json(self.req.backup_name))
         snapshotstate = manifest.snapshot_results[self.req.snapshot_index].state
         assert snapshotstate is not None
 

--- a/tests/unit/common/test_storage.py
+++ b/tests/unit/common/test_storage.py
@@ -62,9 +62,9 @@ def _test_hexdigeststorage(storage: FileStorage) -> None:
 def _test_jsonstorage(storage: JsonStorage) -> None:
     assert storage.list_jsons() == []
     storage.upload_json(TEST_JSON, TEST_JSON_DATA)
-    assert storage.download_json(TEST_JSON) == TEST_JSON_DATA
+    assert storage.download_and_read_json(TEST_JSON) == TEST_JSON_DATA
     with pytest.raises(exceptions.NotFoundException):
-        storage.download_json(TEST_JSON + "x")
+        storage.download_and_read_json(TEST_JSON + "x")
     assert storage.list_jsons() == [TEST_JSON]
     storage.delete_json(TEST_JSON)
     with pytest.raises(exceptions.NotFoundException):
@@ -106,7 +106,7 @@ def test_caching_storage(tmpdir: py.path.local, mocker: MockerFixture) -> None:
     # Nor list hexdigests
     mocklist = mocker.patch.object(storage.backend_storage, "list_jsons")
 
-    assert storage.download_json(TEST_JSON) == TEST_JSON_DATA
+    assert storage.download_and_read_json(TEST_JSON) == TEST_JSON_DATA
     assert storage.list_jsons() == [TEST_JSON]
     assert not mockdown.called
     assert not mocklist.called


### PR DESCRIPTION
* `JsonStorage`: allow downloading a JSON to file rather than memory.
* Add a method to `Step` that allows a cleanup function to run for that step
* `BackupManifestFileWrapper`: wraps a manifest written to disk.

Now we can keep manifests on disk and only use when needed, rather than holding all in memory at the same time.