### PR TITLE
tests: add typing

### DIFF
--- a/astacus/common/rohmustorage.py
+++ b/astacus/common/rohmustorage.py
@@ -208,7 +208,7 @@ class MultiRohmuStorage(MultiStorage[RohmuStorage]):
     def __init__(self, *, config: RohmuConfig) -> None:
         self.config = config
 
-    def get_storage(self, name: str) -> RohmuStorage:
+    def get_storage(self, name: str | None) -> RohmuStorage:
         return RohmuStorage(config=self.config, storage=name)
 
     def get_default_storage_name(self) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def pytest_addoption(parser: Parser) -> None:
     )
 
 
-def pytest_runtest_setup(item):
+def pytest_runtest_setup(item: pytest.Item) -> None:
     if any(item.iter_markers(name="x86_64")) and platform.machine() != "x86_64":
         pytest.skip("x86_64 arch required")
 

--- a/tests/integration/coordinator/plugins/clickhouse/test_plugin.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_plugin.py
@@ -347,7 +347,7 @@ async def test_cleanup_does_not_break_object_storage_disk_files(
     ports: Ports,
     clickhouse_command: ClickHouseCommand,
     minio_bucket: MinioBucket,
-):
+) -> None:
     with tempfile.TemporaryDirectory(prefix="storage_") as storage_path_str:
         storage_path = Path(storage_path_str)
         async with create_zookeeper(ports) as zookeeper:

--- a/tests/integration/coordinator/plugins/flink/test_steps.py
+++ b/tests/integration/coordinator/plugins/flink/test_steps.py
@@ -13,7 +13,7 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_restore_data(zookeeper_client: KazooZooKeeperClient):
+async def test_restore_data(zookeeper_client: KazooZooKeeperClient) -> None:
     table_id1 = str(uuid4()).partition("-")[0]
     table_id2 = str(uuid4()).partition("-")[0]
     data = {

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -2,6 +2,7 @@
 Copyright (c) 2020 Aiven Ltd
 See LICENSE for details
 """
+from _pytest.config import Config
 from astacus.common.utils import AstacusModel, exponential_backoff
 from contextlib import asynccontextmanager
 from httpx import URL
@@ -15,6 +16,7 @@ import httpx
 import json
 import logging
 import os.path
+import py
 import pytest
 import subprocess
 
@@ -134,12 +136,12 @@ async def wait_url_up(url: Union[URL, str]) -> None:
 
 
 @pytest.fixture(name="rootdir")
-def fixture_rootdir(pytestconfig) -> str:
+def fixture_rootdir(pytestconfig: Config) -> str:
     return os.path.join(os.path.dirname(__file__), "..", "..")
 
 
 @asynccontextmanager
-async def _astacus(*, tmpdir, index: int) -> AsyncIterator[TestNode]:
+async def _astacus(*, tmpdir: py.path.local, index: int) -> AsyncIterator[TestNode]:
     node = ASTACUS_NODES[index]
     a_conf_path = create_astacus_config(tmpdir=tmpdir, node=node)
     astacus_source_root = os.path.join(os.path.dirname(__file__), "..", "..")
@@ -151,19 +153,19 @@ async def _astacus(*, tmpdir, index: int) -> AsyncIterator[TestNode]:
 
 
 @pytest.fixture(name="astacus1")
-async def fixture_astacus1(tmpdir) -> AsyncIterator[TestNode]:
+async def fixture_astacus1(tmpdir: py.path.local) -> AsyncIterator[TestNode]:
     async with _astacus(tmpdir=tmpdir, index=0) as a:
         yield a
 
 
 @pytest.fixture(name="astacus2")
-async def fixture_astacus2(tmpdir) -> AsyncIterator[TestNode]:
+async def fixture_astacus2(tmpdir: py.path.local) -> AsyncIterator[TestNode]:
     async with _astacus(tmpdir=tmpdir, index=1) as a:
         yield a
 
 
 @pytest.fixture(name="astacus3")
-async def fixture_astacus3(tmpdir) -> AsyncIterator[TestNode]:
+async def fixture_astacus3(tmpdir: py.path.local) -> AsyncIterator[TestNode]:
     async with _astacus(tmpdir=tmpdir, index=2) as a:
         yield a
 

--- a/tests/system/test_astacus.py
+++ b/tests/system/test_astacus.py
@@ -27,7 +27,7 @@ A1_FILES_AND_CONTENTS = [
 
 # This test is the slowest, so rather fail fast in real unittests before getting here
 @pytest.mark.order("last")
-def test_astacus(astacus1: TestNode, astacus2: TestNode, astacus3: TestNode, rootdir: str):
+def test_astacus(astacus1: TestNode, astacus2: TestNode, astacus3: TestNode, rootdir: str) -> None:
     assert astacus1.root_path
     assert astacus2.root_path
     assert astacus3.root_path

--- a/tests/unit/common/cassandra/test_schema.py
+++ b/tests/unit/common/cassandra/test_schema.py
@@ -5,6 +5,7 @@ See LICENSE for details
 
 from astacus.common.cassandra import schema
 from cassandra import metadata as cm
+from pytest_mock import MockerFixture
 from typing import Mapping
 
 import pytest
@@ -12,7 +13,7 @@ import pytest
 # pylint: disable=protected-access
 
 
-def test_schema(mocker):
+def test_schema(mocker: MockerFixture) -> None:
     cut = schema.CassandraUserType(name="cut", cql_create_self="CREATE-USER-TYPE", field_types=["type1", "type2"])
     cfunction = schema.CassandraFunction(name="cf", cql_create_self="CREATE-FUNCTION", argument_types=["atype1", "atype2"])
 
@@ -26,7 +27,7 @@ def test_schema(mocker):
 
     ctrigger = schema.CassandraTrigger(name="ctrigger", cql_create_self="CREATE-TRIGGER")
 
-    cmv = schema.CassandraIndex(name="cmv", cql_create_self="CREATE-MATERIALIZED-VIEW")
+    cmv = schema.CassandraMaterializedView(name="cmv", cql_create_self="CREATE-MATERIALIZED-VIEW")
 
     ctable = schema.CassandraTable(
         name="ctable", cql_create_self="CREATE-TABLE", indexes=[cindex], materialized_views=[cmv], triggers=[ctrigger]
@@ -96,7 +97,7 @@ def test_schema_keyspace_from_metadata(
     assert keyspace.user_types == []
 
 
-def test_schema_keyspace_iterate_user_types_in_restore_order():
+def test_schema_keyspace_iterate_user_types_in_restore_order() -> None:
     ut1 = schema.CassandraUserType(name="ut1", cql_create_self="", field_types=[])
     ut2 = schema.CassandraUserType(name="ut2", cql_create_self="", field_types=["ut3", "map<str,frozen<ut1>>"])
     ut3 = schema.CassandraUserType(name="ut3", cql_create_self="", field_types=["ut4"])
@@ -131,6 +132,6 @@ def test_schema_keyspace_iterate_user_types_in_restore_order():
         ('"q""u""o""t""e""d"', ['q"u"o"t"e"d']),
     ],
 )
-def test_iterate_identifiers_in_cql_type_definition(definition, identifiers):
+def test_iterate_identifiers_in_cql_type_definition(definition: str, identifiers: list[str]) -> None:
     got_identifiers = list(schema._iterate_identifiers_in_cql_type_definition(definition))
     assert got_identifiers == identifiers

--- a/tests/unit/common/test_m3placement.py
+++ b/tests/unit/common/test_m3placement.py
@@ -23,7 +23,7 @@ dst_pnode = m3placement.M3PlacementNode(
 )
 
 
-def create_dummy_placement():
+def create_dummy_placement() -> m3_placement_pb2.Placement:
     placement = m3_placement_pb2.Placement()
     instance = placement.instances["node-id1"]
     instance.id = "node-id1"
@@ -32,7 +32,7 @@ def create_dummy_placement():
     return placement
 
 
-def test_rewrite_single_m3_placement_node():
+def test_rewrite_single_m3_placement_node() -> None:
     placement = create_dummy_placement()
     m3placement.rewrite_single_m3_placement_node(
         placement, src_pnode=src_pnode, dst_pnode=dst_pnode, dst_isolation_group="az22"
@@ -43,7 +43,7 @@ def test_rewrite_single_m3_placement_node():
     assert instance2.isolation_group == "az22"
 
 
-def test_rewrite_m3_placement_bytes():
+def test_rewrite_m3_placement_bytes() -> None:
     value = create_dummy_placement().SerializeToString()
     assert isinstance(value, bytes)
     expected_bytes = [b"endpoint22", b"hostname22", b"az22"]

--- a/tests/unit/common/test_op_stats.py
+++ b/tests/unit/common/test_op_stats.py
@@ -40,7 +40,7 @@ class DummyStep3(DummyStep):
 
 
 @pytest.mark.asyncio
-async def test_op_stats():
+async def test_op_stats() -> None:
     stats = StatsClient(config=None)
     coordinator = Coordinator(
         request_url=URL(),
@@ -73,7 +73,7 @@ class DummyOp(op.Op):
     pass
 
 
-def test_status_fail_stats():
+def test_status_fail_stats() -> None:
     stats = StatsClient(config=None)
     operation = DummyOp(info=op.Op.Info(op_id=1, op_name="DummyOp"), op_id=1, stats=stats)
 

--- a/tests/unit/common/test_progress.py
+++ b/tests/unit/common/test_progress.py
@@ -32,12 +32,12 @@ import pytest
         (16676, None, None, False),
     ],
 )
-def test_increase_worth_reporting(old_value, new_value, total, exp):
+def test_increase_worth_reporting(old_value: int, new_value: int | None, total: int | None, exp: bool) -> None:
     assert progress.increase_worth_reporting(old_value, new_value, total=total) == exp
 
 
 @pytest.mark.parametrize("is_final", [True, False])
-def test_progress_merge(is_final):
+def test_progress_merge(is_final: bool) -> None:
     p1 = progress.Progress(handled=0, failed=1000, total=10, final=True)
     p2 = progress.Progress(handled=100, failed=100, total=1000, final=is_final)
     p3 = progress.Progress(handled=1000, failed=10, total=10000, final=True)

--- a/tests/unit/common/test_statsd.py
+++ b/tests/unit/common/test_statsd.py
@@ -26,9 +26,9 @@ class _Protocol(asyncio.DatagramProtocol):
 
 
 @pytest.mark.asyncio
-async def test_statsd():
+async def test_statsd() -> None:
     loop = asyncio.get_running_loop()
-    received = asyncio.Queue()
+    received: asyncio.Queue[bytes] = asyncio.Queue()
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.bind(("", 0))

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,45 +3,21 @@ Copyright (c) 2020 Aiven Ltd
 See LICENSE for details
 """
 
-from astacus.common import utils
 from astacus.common.cassandra.config import CassandraClientConfiguration, SNAPSHOT_NAME
 from io import StringIO
 from pathlib import Path
+from pytest_mock import MockerFixture
 
 import logging
+import py
 import pytest
 import tempfile
 
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture(name="utils_http_request_list")
-def fixture_utils_http_request_list(mocker):
-    result_list = []
-
-    def _http_request(*args, **kwargs):
-        logger.info("utils_http_request_list %r %r", args, kwargs)
-        assert result_list, f"Unable to serve request {args!r} {kwargs!r}"
-        r = result_list.pop(0)
-        if isinstance(r, dict):
-            if "args" in r:
-                assert list(r["args"]) == list(args)
-            if "kwargs" in r:
-                assert r["kwargs"] == kwargs
-            if "result" in r:
-                return r["result"]
-            return None
-        if r is None:
-            return None
-        raise NotImplementedError(f"Unknown item in utils_request_list: {r!r}")
-
-    mocker.patch.object(utils, "http_request", new=_http_request)
-    yield result_list
-    assert not result_list, f"Unconsumed requests: {result_list!r}"
-
-
 class CassandraTestConfig:
-    def __init__(self, *, mocker, tmpdir):
+    def __init__(self, *, mocker: MockerFixture, tmpdir: py.path.local):
         self.root = Path(tmpdir) / "root"
 
         # Create fake snapshot files that we want to see being moved/removed/..
@@ -87,5 +63,5 @@ listen_address: 127.0.0.1
 
 
 @pytest.fixture(name="cassandra_test_config")
-def fixture_cassandra_test_config(mocker, tmpdir):
-    yield CassandraTestConfig(mocker=mocker, tmpdir=tmpdir)
+def fixture_cassandra_test_config(mocker: MockerFixture, tmpdir: py.path.local) -> CassandraTestConfig:
+    return CassandraTestConfig(mocker=mocker, tmpdir=tmpdir)

--- a/tests/unit/coordinator/conftest.py
+++ b/tests/unit/coordinator/conftest.py
@@ -3,27 +3,31 @@ Copyright (c) 2020 Aiven Ltd
 See LICENSE for details
 """
 from .test_restore import BACKUP_MANIFEST
+from astacus.common.ipc import Plugin
 from astacus.common.rohmustorage import MultiRohmuStorage, RohmuStorage
 from astacus.coordinator.api import router
 from astacus.coordinator.config import CoordinatorConfig, CoordinatorNode
 from astacus.coordinator.coordinator import LockedCoordinatorOp
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from pathlib import Path
+from pytest_mock import MockerFixture
 from tests.utils import create_rohmu_config
 
 import asyncio
+import py
 import pytest
 
 _original_asyncio_sleep = asyncio.sleep
 
 
 @pytest.fixture(name="storage")
-def fixture_storage(tmpdir):
+def fixture_storage(tmpdir: py.path.local) -> RohmuStorage:
     return RohmuStorage(config=create_rohmu_config(tmpdir))
 
 
 @pytest.fixture(name="mstorage")
-def fixture_mstorage(tmpdir):
+def fixture_mstorage(tmpdir: py.path.local) -> MultiRohmuStorage:
     return MultiRohmuStorage(config=create_rohmu_config(tmpdir))
 
 
@@ -40,22 +44,22 @@ def fixture_populated_mstorage(mstorage: MultiRohmuStorage) -> MultiRohmuStorage
 
 
 @pytest.fixture(name="client")
-def fixture_client(app):
+def fixture_client(app: FastAPI) -> TestClient:
     client = TestClient(app)
 
     # One ping at API to populate the fixtures (ugh)
     response = client.post("/lock")
     assert response.status_code == 422, response.json()
 
-    yield client
+    return client
 
 
-async def _sleep_little(value):
+async def _sleep_little(value: float) -> None:
     await _original_asyncio_sleep(min(value, 0.01))
 
 
 @pytest.fixture(name="sleepless")
-def fixture_sleepless(mocker):
+def fixture_sleepless(mocker: MockerFixture) -> None:
     mocker.patch.object(asyncio, "sleep", new=_sleep_little)
 
 
@@ -66,15 +70,15 @@ COORDINATOR_NODES = [
 
 
 @pytest.fixture(name="app")
-def fixture_app(mocker, sleepless, storage, tmpdir):
+def fixture_app(mocker: MockerFixture, sleepless: None, storage: RohmuStorage, tmpdir: py.path.local) -> FastAPI:
     app = FastAPI()
     app.include_router(router, tags=["coordinator"])
     app.state.coordinator_config = CoordinatorConfig(
         object_storage=create_rohmu_config(tmpdir),
-        plugin="files",
+        plugin=Plugin.files,
         plugin_config={"root_globs": ["*"]},
-        object_storage_cache=f"{tmpdir}/cache/is/somewhere",
+        object_storage_cache=Path(f"{tmpdir}/cache/is/somewhere"),
     )
     app.state.coordinator_config.nodes = COORDINATOR_NODES[:]
     mocker.patch.object(LockedCoordinatorOp, "get_locker", return_value="x")
-    yield app
+    return app

--- a/tests/unit/coordinator/plugins/cassandra/test_plugin.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_plugin.py
@@ -4,55 +4,55 @@ See LICENSE for details
 """
 
 from astacus.common import ipc
-from astacus.coordinator.plugins.base import StepFailedError
+from astacus.coordinator.cluster import Cluster
+from astacus.coordinator.plugins.base import StepFailedError, StepsContext
 from astacus.coordinator.plugins.cassandra import plugin
 from astacus.coordinator.plugins.cassandra.model import CassandraConfigurationNode
+from pytest_mock import MockerFixture
 from tests.unit.conftest import CassandraTestConfig
-from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
 
 @pytest.fixture(name="cplugin")
-def fixture_cplugin(mocker, tmpdir):
-    ctc = CassandraTestConfig(mocker=mocker, tmpdir=tmpdir)
-    yield plugin.CassandraPlugin(
-        client=ctc.cassandra_client_config, nodes=[CassandraConfigurationNode(listen_address="127.0.0.1")]
+def fixture_cplugin(cassandra_test_config: CassandraTestConfig) -> plugin.CassandraPlugin:
+    return plugin.CassandraPlugin(
+        client=cassandra_test_config.cassandra_client_config,
+        nodes=[CassandraConfigurationNode(listen_address="127.0.0.1")],
     )
 
 
 @pytest.mark.asyncio
-async def test_step_cassandrasubop(mocker):
+async def test_step_cassandrasubop(mocker: MockerFixture) -> None:
     mocker.patch.object(plugin, "run_subop")
 
     step = plugin.CassandraSubOpStep(op=ipc.CassandraSubOp.stop_cassandra)
-    cluster = None
-    context = None
-    result = await step.run_step(cluster, context)
-    assert result is None
+    cluster = Cluster(nodes=[])
+    context = StepsContext()
+    await step.run_step(cluster, context)
 
 
 @pytest.mark.parametrize("success", [False, True])
 @pytest.mark.asyncio
-async def test_step_cassandra_validate_configuration(mocker, success):
+async def test_step_cassandra_validate_configuration(mocker: MockerFixture, success: bool) -> None:
     step = plugin.ValidateConfigurationStep(nodes=[])
-    context = None
+    context = Mock()
     if success:
-        cluster = SimpleNamespace(nodes=[])
-        result = await step.run_step(cluster, context)
-        assert result is None
+        cluster = Mock(nodes=[])
+        await step.run_step(cluster, context)
     else:
         # node count mismatch
-        cluster = SimpleNamespace(nodes=[42])
+        cluster = Mock(nodes=[42])
         with pytest.raises(StepFailedError):
             await step.run_step(cluster, context)
 
 
-def test_get_backup_steps(mocker, cplugin):
+def test_get_backup_steps(mocker: MockerFixture, cplugin):
     context = mocker.Mock()
     cplugin.get_backup_steps(context=context)
 
 
-def test_get_restore_steps(mocker, cplugin):
+def test_get_restore_steps(mocker: MockerFixture, cplugin):
     context = mocker.Mock()
     cplugin.get_restore_steps(context=context, req=ipc.RestoreRequest())

--- a/tests/unit/coordinator/plugins/cassandra/test_restore_steps.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_restore_steps.py
@@ -5,12 +5,14 @@ See LICENSE for details
 
 from astacus.common import ipc
 from astacus.common.cassandra.schema import CassandraSchema
+from astacus.coordinator.cluster import Cluster
 from astacus.coordinator.config import CoordinatorNode
 from astacus.coordinator.plugins import base
 from astacus.coordinator.plugins.cassandra import restore_steps
 from astacus.coordinator.plugins.cassandra.model import CassandraConfigurationNode, CassandraManifest, CassandraManifestNode
+from pytest_mock import MockerFixture
 from tests.unit.coordinator.plugins.cassandra.builders import build_keyspace
-from types import SimpleNamespace
+from unittest.mock import Mock
 from uuid import UUID
 
 import datetime
@@ -51,7 +53,7 @@ _pr_node = ipc.PartialRestoreRequestNode
 @pytest.mark.parametrize("override_tokens", [False, True])
 @pytest.mark.parametrize("replace_backup_nodes", [False, True])
 @pytest.mark.asyncio
-async def test_step_start_cassandra(mocker, override_tokens, replace_backup_nodes):
+async def test_step_start_cassandra(mocker: MockerFixture, override_tokens: bool, replace_backup_nodes: bool) -> None:
     plugin_manifest = CassandraManifest(
         cassandra_schema=CassandraSchema(keyspaces=[]),
         nodes=[_manifest_node(1)],
@@ -93,10 +95,10 @@ async def test_step_start_cassandra(mocker, override_tokens, replace_backup_node
     step = restore_steps.StartCassandraStep(
         replace_backup_nodes=replace_backup_nodes, override_tokens=override_tokens, cassandra_nodes=[_configuration_node(1)]
     )
-    context = SimpleNamespace(get_result=get_result)
-    cluster = SimpleNamespace(nodes=nodes)
-    result = await step.run_step(cluster, context)
-    assert result is None
+    context = base.StepsContext()
+    mocker.patch.object(context, "get_result", new=get_result)
+    cluster = Cluster(nodes=nodes)
+    await step.run_step(cluster, context)
     run_subop.assert_awaited_once_with(
         cluster,
         ipc.CassandraSubOp.start_cassandra,
@@ -107,7 +109,7 @@ async def test_step_start_cassandra(mocker, override_tokens, replace_backup_node
 
 
 @pytest.mark.asyncio
-async def test_step_stop_replaced_nodes(mocker):
+async def test_step_stop_replaced_nodes(mocker: MockerFixture) -> None:
     # Node 3 is replacing node 1.
     manifest_nodes = [_manifest_node(1), _manifest_node(2)]
     cassandra_nodes = [_configuration_node(1), _configuration_node(2), _configuration_node(3)]
@@ -129,8 +131,8 @@ async def test_step_stop_replaced_nodes(mocker):
     run_subop = mocker.patch.object(restore_steps, "run_subop")
 
     step = restore_steps.StopReplacedNodesStep(partial_restore_nodes=partial_restore_nodes, cassandra_nodes=cassandra_nodes)
-    context = SimpleNamespace(get_result=get_result)
-    cluster = SimpleNamespace(nodes=nodes)
+    context = Mock(get_result=get_result)
+    cluster = Mock(nodes=nodes)
     result = await step.run_step(cluster, context)
     assert result == [_coordinator_node(1)]
     run_subop.assert_awaited_once_with(
@@ -158,7 +160,7 @@ class AsyncIterableWrapper:
 
 @pytest.mark.parametrize("steps,success", [([True], True), ([False, True], True), ([False], False)])
 @pytest.mark.asyncio
-async def test_step_wait_cassandra_up(mocker, steps, success):
+async def test_step_wait_cassandra_up(mocker: MockerFixture, steps: list[bool], success: bool) -> None:
     get_schema_steps = steps[:]
 
     async def get_schema_hash(cluster):
@@ -167,14 +169,17 @@ async def test_step_wait_cassandra_up(mocker, steps, success):
 
     mocker.patch.object(restore_steps, "get_schema_hash", new=get_schema_hash)
 
-    mocker.patch.object(restore_steps.utils, "exponential_backoff", return_value=AsyncIterableWrapper(steps))
+    mocker.patch.object(
+        restore_steps.utils,  # type: ignore[attr-defined]
+        "exponential_backoff",
+        return_value=AsyncIterableWrapper(steps),
+    )
 
     step = restore_steps.WaitCassandraUpStep(duration=123)
-    context = None
-    cluster = None
+    cluster = Cluster(nodes=[])
+    context = base.StepsContext()
     if success:
-        result = await step.run_step(cluster, context)
-        assert result is None
+        await step.run_step(cluster, context)
     else:
         with pytest.raises(base.StepFailedError):
             await step.run_step(cluster, context)

--- a/tests/unit/coordinator/plugins/cassandra/test_utils.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_utils.py
@@ -6,14 +6,15 @@ See LICENSE for details
 from astacus.common import ipc
 from astacus.coordinator.plugins.base import StepFailedError
 from astacus.coordinator.plugins.cassandra import utils
-from types import SimpleNamespace
+from pytest_mock import MockerFixture
+from unittest.mock import Mock
 
 import pytest
 
 
 @pytest.mark.parametrize("start_ok", [False, True])
 @pytest.mark.asyncio
-async def test_run_subop(mocker, start_ok):
+async def test_run_subop(mocker: MockerFixture, start_ok: bool) -> None:
     async def request_from_nodes(*args, **kwargs):
         if start_ok:
             return 42
@@ -23,7 +24,7 @@ async def test_run_subop(mocker, start_ok):
         assert start_results == 42
         return 7
 
-    cluster = SimpleNamespace(request_from_nodes=request_from_nodes, wait_successful_results=wait_successful_results)
+    cluster = Mock(request_from_nodes=request_from_nodes, wait_successful_results=wait_successful_results)
     try:
         result = await utils.run_subop(cluster=cluster, subop=ipc.CassandraSubOp.stop_cassandra, result_class=ipc.NodeResult)
     except StepFailedError:
@@ -42,7 +43,7 @@ async def test_run_subop(mocker, start_ok):
     ],
 )
 @pytest.mark.asyncio
-async def test_get_schema_hash(mocker, hashes, result):
-    mocker.patch.object(utils, "run_subop", return_value=[SimpleNamespace(schema_hash=hash) for hash in hashes])
-    actual_result = await utils.get_schema_hash(None)
+async def test_get_schema_hash(mocker: MockerFixture, hashes: list[int], result: tuple[str, str]) -> None:
+    mocker.patch.object(utils, "run_subop", return_value=[Mock(schema_hash=hash) for hash in hashes])
+    actual_result = await utils.get_schema_hash(mocker.Mock())
     assert actual_result == result

--- a/tests/unit/coordinator/plugins/test_m3db.py
+++ b/tests/unit/coordinator/plugins/test_m3db.py
@@ -135,7 +135,7 @@ class RestoreTest:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("rt", [RestoreTest(fail_at=i) for i in range(3)] + [RestoreTest()])
-async def test_m3_restore(coordinator: Coordinator, plugin: M3DBPlugin, etcd_client: ETCDClient, rt: RestoreTest):
+async def test_m3_restore(coordinator: Coordinator, plugin: M3DBPlugin, etcd_client: ETCDClient, rt: RestoreTest) -> None:
     partial_restore_nodes: Optional[List[ipc.PartialRestoreRequestNode]] = None
     if rt.partial:
         partial_restore_nodes = [ipc.PartialRestoreRequestNode(backup_index=0, node_index=0)]

--- a/tests/unit/coordinator/plugins/test_zookeeper.py
+++ b/tests/unit/coordinator/plugins/test_zookeeper.py
@@ -173,7 +173,7 @@ async def test_fake_zookeeper_client_get_children_watch() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fake_zookeeper_transaction():
+async def test_fake_zookeeper_transaction() -> None:
     client = FakeZooKeeperClient()
     async with client.connect() as connection:
         transaction = connection.transaction()
@@ -185,7 +185,7 @@ async def test_fake_zookeeper_transaction():
 
 
 @pytest.mark.asyncio
-async def test_fake_zookeeper_transaction_is_atomic():
+async def test_fake_zookeeper_transaction_is_atomic() -> None:
     client = FakeZooKeeperClient()
     async with client.connect() as connection:
         await connection.create("/key_2", b"old content")
@@ -203,7 +203,7 @@ async def test_fake_zookeeper_transaction_is_atomic():
 
 
 @pytest.mark.asyncio
-async def test_fake_zookeeper_transaction_does_not_implicitly_create_parents():
+async def test_fake_zookeeper_transaction_does_not_implicitly_create_parents() -> None:
     client = FakeZooKeeperClient()
     async with client.connect() as connection:
         transaction = connection.transaction()
@@ -213,7 +213,7 @@ async def test_fake_zookeeper_transaction_does_not_implicitly_create_parents():
 
 
 @pytest.mark.asyncio
-async def test_fake_zookeeper_transaction_generates_trigger():
+async def test_fake_zookeeper_transaction_generates_trigger() -> None:
     client = FakeZooKeeperClient()
     change_watch = ChangeWatch()
     async with client.connect() as connection:

--- a/tests/unit/coordinator/test_cleanup.py
+++ b/tests/unit/coordinator/test_cleanup.py
@@ -6,6 +6,9 @@ Test that the cleanup endpoint behaves as advertised
 """
 
 from astacus.common import ipc
+from astacus.common.rohmustorage import MultiRohmuStorage
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 import pytest
 import respx
@@ -13,7 +16,16 @@ import respx
 FAILS = [1, None]
 
 
-def _run(*, client, populated_mstorage, app, fail_at=None, retention, exp_jsons, exp_digests):
+def _run(
+    *,
+    client: TestClient,
+    populated_mstorage: MultiRohmuStorage,
+    app: FastAPI,
+    fail_at: int | None = None,
+    retention: ipc.Retention,
+    exp_jsons: int,
+    exp_digests: int,
+) -> None:
     app.state.coordinator_config.retention = retention
     assert len(populated_mstorage.get_storage("x").list_jsons()) == 2
     populated_mstorage.get_storage("x").upload_hexdigest_bytes("TOBEDELETED", b"x")
@@ -44,7 +56,9 @@ def _run(*, client, populated_mstorage, app, fail_at=None, retention, exp_jsons,
 
 
 @pytest.mark.parametrize("fail_at", FAILS)
-def test_api_cleanup_flow(fail_at, client, populated_mstorage, app):
+def test_api_cleanup_flow(
+    fail_at: int | None, client: TestClient, populated_mstorage: MultiRohmuStorage, app: FastAPI
+) -> None:
     _run(
         fail_at=fail_at,
         client=client,
@@ -69,7 +83,9 @@ def test_api_cleanup_flow(fail_at, client, populated_mstorage, app):
         (ipc.Retention(maximum_backups=1, keep_days=10000), 1, 1),
     ],
 )
-def test_api_cleanup_retention(data, client, populated_mstorage, app):
+def test_api_cleanup_retention(
+    data: tuple[ipc.Retention, int, int], client: TestClient, populated_mstorage: MultiRohmuStorage, app: FastAPI
+) -> None:
     retention, exp_jsons, exp_digests = data
     _run(
         client=client,

--- a/tests/unit/coordinator/test_list.py
+++ b/tests/unit/coordinator/test_list.py
@@ -23,13 +23,14 @@ from astacus.coordinator.list import compute_deduplicated_snapshot_file_stats, l
 from fastapi.testclient import TestClient
 from os import PathLike
 from pathlib import Path
+from pytest_mock import MockerFixture
 from tests.utils import create_rohmu_config
 
 import datetime
 import pytest
 
 
-def test_api_list(client: TestClient, populated_mstorage: MultiRohmuStorage, mocker) -> None:
+def test_api_list(client: TestClient, populated_mstorage: MultiRohmuStorage, mocker: MockerFixture) -> None:
     assert populated_mstorage
 
     def _run():

--- a/tests/unit/coordinator/test_lock.py
+++ b/tests/unit/coordinator/test_lock.py
@@ -8,18 +8,20 @@ Test that the coordinator lock endpoint works.
 
 from astacus.common.magic import LockCall
 from astacus.common.statsd import StatsClient
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from unittest.mock import patch
 
 import respx
 
 
-def test_status_nonexistent(client):
+def test_status_nonexistent(client: TestClient) -> None:
     response = client.get("/lock/123")
     assert response.status_code == 404
     assert response.json() == {"detail": {"code": "operation_id_mismatch", "message": "Unknown operation id", "op": 123}}
 
 
-def test_lock_no_nodes(app, client):
+def test_lock_no_nodes(app: FastAPI, client: TestClient) -> None:
     nodes = app.state.coordinator_config.nodes
     nodes.clear()
 
@@ -35,7 +37,7 @@ def test_lock_no_nodes(app, client):
     assert response.json() == {"state": "done"}
 
 
-def test_lock_ok(app, client):
+def test_lock_ok(app: FastAPI, client: TestClient) -> None:
     nodes = app.state.coordinator_config.nodes
     with respx.mock:
         for node in nodes:
@@ -50,7 +52,7 @@ def test_lock_ok(app, client):
         assert app.state.coordinator_state.op_info.op_id == 1
 
 
-def test_lock_onefail(app, client):
+def test_lock_onefail(app: FastAPI, client: TestClient) -> None:
     nodes = app.state.coordinator_config.nodes
     with respx.mock:
         for i, node in enumerate(nodes):

--- a/tests/unit/node/conftest.py
+++ b/tests/unit/node/conftest.py
@@ -16,11 +16,12 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from pathlib import Path
 
+import py
 import pytest
 
 
 @pytest.fixture(name="app")
-def fixture_app(tmpdir) -> FastAPI:
+def fixture_app(tmpdir: py.path.local) -> FastAPI:
     app = FastAPI()
     app.include_router(node_router, prefix="/node", tags=["node"])
     root = Path(tmpdir) / "root"
@@ -65,33 +66,33 @@ def fixture_uploader(storage):
 
 
 @pytest.fixture(name="storage")
-def fixture_storage(tmpdir) -> FileStorage:
+def fixture_storage(tmpdir: py.path.local) -> FileStorage:
     storage_path = Path(tmpdir) / "storage"
     storage_path.mkdir()
     return FileStorage(storage_path)
 
 
 @pytest.fixture(name="root")
-def fixture_root(tmpdir) -> Path:
+def fixture_root(tmpdir: py.path.local) -> Path:
     return Path(tmpdir)
 
 
 @pytest.fixture(name="src")
-def fixture_src(tmpdir) -> Path:
+def fixture_src(tmpdir: py.path.local) -> Path:
     src = Path(tmpdir) / "src"
     src.mkdir()
     return src
 
 
 @pytest.fixture(name="dst")
-def fixture_dst(tmpdir) -> Path:
+def fixture_dst(tmpdir: py.path.local) -> Path:
     dst = Path(tmpdir) / "dst"
     dst.mkdir()
     return dst
 
 
 @pytest.fixture(name="db")
-def fixture_db(tmpdir) -> Path:
+def fixture_db(tmpdir: py.path.local) -> Path:
     db = Path(tmpdir) / "db"
     return db
 

--- a/tests/unit/node/test_node_lock.py
+++ b/tests/unit/node/test_node_lock.py
@@ -4,7 +4,10 @@ See LICENSE for details
 """
 
 
-def test_api_lock_unlock(client):
+from fastapi.testclient import TestClient
+
+
+def test_api_lock_unlock(client: TestClient) -> None:
     # Play with lock
     response = client.post("/node/lock")
     assert response.status_code == 422, response.json()

--- a/tests/unit/node/test_node_snapshot.py
+++ b/tests/unit/node/test_node_snapshot.py
@@ -27,7 +27,7 @@ def test_snapshot(
     dst: Path,
     db: Path,
     src_is_dst: bool,
-):
+) -> None:
     if src_is_dst:
         dst = src
 
@@ -89,7 +89,7 @@ def test_snapshot(
         assert not hashes_empty
 
 
-def test_api_snapshot_and_upload(client: TestClient, mocker: MockerFixture):
+def test_api_snapshot_and_upload(client: TestClient, mocker: MockerFixture) -> None:
     url = "http://addr/result"
     m = mocker.patch.object(utils, "http_request")
     response = client.post("/node/snapshot")
@@ -129,7 +129,7 @@ def test_api_snapshot_and_upload(client: TestClient, mocker: MockerFixture):
     assert result2.progress.finished_successfully
 
 
-def test_api_snapshot_error(client, mocker):
+def test_api_snapshot_error(client: TestClient, mocker: MockerFixture) -> None:
     req_json = {"root_globs": ["*"]}
     response = client.post("/node/lock?locker=x&ttl=10")
     assert response.status_code == 200, response.json()
@@ -170,7 +170,7 @@ def test_snapshot_file_size_changed(
     src_is_dst: bool,
     truncate_to,
     hashes_in_second_snapshot: int,
-):
+) -> None:
     if src_is_dst:
         dst = src
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,17 +4,18 @@ See LICENSE for details
 """
 from astacus.common.rohmustorage import RohmuConfig
 from pathlib import Path
-from typing import List, Union
+from typing import Final, List, Union
 
 import importlib
 import os
+import py
 import re
 import subprocess
 import sys
 
 # These test keys are from copied from pghoard
 
-CONSTANT_TEST_RSA_PUBLIC_KEY = """\
+CONSTANT_TEST_RSA_PUBLIC_KEY: Final = """\
 -----BEGIN PUBLIC KEY-----
 MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDQ9yu7rNmu0GFMYeQq9Jo2B3d9
 hv5t4a+54TbbxpJlks8T27ipgsaIjqiQP7+uXNfU6UCzGFEHs9R5OELtO3Hq0Dn+
@@ -22,7 +23,7 @@ JGdxJlJ1prxVkvjCICCpiOkhc2ytmn3PWRuVf2VyeAddslEWHuXhZPptvIr593kF
 lWN+9KPe+5bXS8of+wIDAQAB
 -----END PUBLIC KEY-----"""
 
-CONSTANT_TEST_RSA_PRIVATE_KEY = """\
+CONSTANT_TEST_RSA_PRIVATE_KEY: Final = """\
 -----BEGIN PRIVATE KEY-----
 MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAND3K7us2a7QYUxh
 5Cr0mjYHd32G/m3hr7nhNtvGkmWSzxPbuKmCxoiOqJA/v65c19TpQLMYUQez1Hk4
@@ -41,7 +42,7 @@ nkMAHqg9PS372Cs=
 -----END PRIVATE KEY-----"""
 
 
-def create_rohmu_config(tmpdir, *, compression=True, encryption=True) -> RohmuConfig:
+def create_rohmu_config(tmpdir: py.path.local, *, compression: bool = True, encryption: bool = True) -> RohmuConfig:
     x_path = Path(tmpdir) / "rohmu-x"
     x_path.mkdir(exist_ok=True)
     y_path = Path(tmpdir) / "rohmu-y"


### PR DESCRIPTION
Been having some trouble reading tests without type annotations.

* add missing types to test methods
* remove unused fixtures `fixture_utils_http_request_list`
* just use `Mock` instead of `SimpleNamespace`, it is better for typing (mypy understands that `Mock` is a subtype / supertype of every type similar to `Any`).