### PR TITLE
reduce astacus memory usage [DDB-853]

### DIFF
--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -74,7 +74,7 @@ class MetadataResult(AstacusModel):
 
 @functools.total_ordering
 class SnapshotFile(AstacusModel):
-    relative_path: Path
+    relative_path: str
     file_size: int
     mtime_ns: int
     hexdigest: str = ""

--- a/astacus/common/json_view.py
+++ b/astacus/common/json_view.py
@@ -1,0 +1,149 @@
+"""
+Copyright (c) 2024 Aiven Ltd
+See LICENSE for details
+"""
+from collections.abc import Iterator, Mapping, Sequence
+from typing import TypeAlias
+
+import enum
+
+JsonScalar: TypeAlias = str | int | float | None
+JsonArrayView: TypeAlias = Sequence["JsonView"]
+JsonObjectView: TypeAlias = Mapping[str, "JsonView"]
+JsonView: TypeAlias = JsonScalar | JsonObjectView | JsonArrayView
+
+
+class JsonParseError(ValueError):
+    pass
+
+
+class Undefined(enum.Enum):
+    undef = object()
+
+
+def iter_objects(json_array_view: JsonArrayView) -> Iterator[JsonObjectView]:
+    """Return an iterator of JsonObjectView, checking that all items in the list are objects."""
+    for i, item in enumerate(json_array_view):
+        if not isinstance(item, Mapping):
+            raise JsonParseError(f"Unexpected type at index {i}: expected Mapping, got {item.__class__.__name__}")
+        yield item
+
+
+def get_array(
+    json_object_view: JsonObjectView, key: str, default: JsonArrayView | Undefined = Undefined.undef
+) -> JsonArrayView:
+    """Return an iterator of JsonObjectView, the key is required unless a default is provided."""
+    value = get_any(json_object_view, key, default)
+    if not isinstance(value, Sequence):
+        raise JsonParseError(f"Unexpected type for {key}: expected Sequence, got {value.__class__.__name__}")
+    return value
+
+
+def get_object(
+    json_object_view: JsonObjectView, key: str, default: JsonObjectView | Undefined = Undefined.undef
+) -> JsonObjectView:
+    """Return an JsonObjectView, the key is required unless a default is provided."""
+    value = get_any(json_object_view, key, default)
+    if not isinstance(value, Mapping):
+        raise JsonParseError(f"Unexpected type for {key}: expected Mapping, got {value.__class__.__name__}")
+    return value
+
+
+def get_str(json_object_view: JsonObjectView, key: str, default: str | Undefined = Undefined.undef) -> str:
+    """Return a str, the key is required unless a default is provided."""
+    value = get_any(json_object_view, key, default)
+    if not isinstance(value, str):
+        raise JsonParseError(f"Unexpected type for {key}: expected str, got {value.__class__.__name__}")
+    return value
+
+
+def get_int(json_object_view: JsonObjectView, key: str, default: int | Undefined = Undefined.undef) -> int:
+    """
+    Return an int, the key is required unless a default is provided.
+    Despite bool being a subtype of int in Python, they are dynamically rejected to avoid confusion
+    and bugs when 1 and True are both accepted in a JSON file but with a different meaning.
+    """
+    if isinstance(default, bool):
+        raise ValueError("Unexpected type for default value, expected int or Undefined, got bool")
+    value = get_any(json_object_view, key, default)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise JsonParseError(f"Unexpected type for {key}: expected int, got {value.__class__.__name__}")
+    return value
+
+
+def get_float(json_object_view: JsonObjectView, key: str, default: float | Undefined = Undefined.undef) -> float:
+    """Return a float, the key is required unless a default is provided."""
+    value = get_any(json_object_view, key, default)
+    if isinstance(value, int):
+        return float(value)
+    if not isinstance(value, float):
+        raise JsonParseError(f"Unexpected type for {key}: expected float, got {value.__class__.__name__}")
+    return value
+
+
+def get_bool(json_object_view: JsonObjectView, key: str, default: bool | Undefined = Undefined.undef) -> bool:
+    """Return a bool, the key is required unless a default is provided."""
+    value = get_any(json_object_view, key, default)
+    if not isinstance(value, bool):
+        raise JsonParseError(f"Unexpected type for {key}: expected bool, got {value.__class__.__name__}")
+    return value
+
+
+def get_optional_object(
+    json_object_view: JsonObjectView, key: str, default: JsonObjectView | None | Undefined = None
+) -> JsonObjectView | None:
+    """Return a JsonObjectView or None, the key is optional unless the default is set to `Undefined.undef`."""
+    value = get_any(json_object_view, key, default)
+    if value is not None and not isinstance(value, Mapping):
+        raise JsonParseError(f"Unexpected type for {key}: expected Mapping or None, got {value.__class__.__name__}")
+    return value
+
+
+def get_optional_bool(json_object_view: JsonObjectView, key: str, default: bool | None | Undefined = None) -> bool | None:
+    """Return a bool or None, the key is optional unless the default is set to `Undefined.undef`."""
+    value = get_any(json_object_view, key, default)
+    if value is not None and not isinstance(value, bool):
+        raise JsonParseError(f"Unexpected type for {key}: expected bool or None, got {value.__class__.__name__}")
+    return value
+
+
+def get_optional_str(json_object_view: JsonObjectView, key: str, default: str | None | Undefined = None) -> str | None:
+    """Return a str or None, the key is optional unless the default is set to `Undefined.undef`."""
+    value = get_any(json_object_view, key, default)
+    if value is not None and not isinstance(value, str):
+        raise JsonParseError(f"Unexpected type for {key}: expected str or None, got {value.__class__.__name__}")
+    return value
+
+
+def get_optional_int(json_object_view: JsonObjectView, key: str, default: int | None | Undefined = None) -> int | None:
+    """
+    Return an int or None, the key is optional unless the default is set to `Undefined.undef`.
+    Despite bool being a subtype of int in Python, they are dynamically rejected to avoid confusion
+    and bugs when 1 and True are both accepted in a JSON file but with a different meaning.
+    """
+    if isinstance(default, bool):
+        raise ValueError("Unexpected type for default value, expected int, None or Undefined, got bool")
+    value = get_any(json_object_view, key, default)
+    if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
+        raise JsonParseError(f"Unexpected type for {key}: expected int or None, got {value.__class__.__name__}")
+    return value
+
+
+def get_optional_float(json_object_view: JsonObjectView, key: str, default: float | None | Undefined = None) -> float | None:
+    """Return a float or None, the key is optional unless the default is set to `Undefined.undef`."""
+    value = get_any(json_object_view, key, default)
+    if isinstance(value, int):
+        return float(value)
+    if value is not None and not isinstance(value, float):
+        raise JsonParseError(f"Unexpected type for {key}: expected float or None, got {value.__class__.__name__}")
+    return value
+
+
+def get_any(json_object_view: JsonObjectView, key: str, default: JsonView | Undefined = Undefined.undef) -> JsonView:
+    """Return a JsonView, the key is required unless a default is provided."""
+    if default is not Undefined.undef:
+        return json_object_view.get(key, default)
+    try:
+        return json_object_view[key]
+    except KeyError as e:
+        raise JsonParseError(f"Missing key in object: {key}") from e

--- a/astacus/coordinator/list.py
+++ b/astacus/coordinator/list.py
@@ -4,12 +4,23 @@ See LICENSE for details
 
 """
 from astacus.common import ipc, magic
+from astacus.common.json_view import (
+    get_array,
+    get_int,
+    get_optional_object,
+    get_optional_str,
+    get_str,
+    iter_objects,
+    JsonArrayView,
+)
 from astacus.common.storage import JsonStorage, MultiStorage
+from astacus.common.utils import now
 from collections import defaultdict
 from collections.abc import Iterator
+from pydantic.datetime_parse import parse_datetime
 
 
-def compute_deduplicated_snapshot_file_stats(manifest: ipc.BackupManifest) -> tuple[int, int]:
+def compute_deduplicated_snapshot_file_stats(snapshot_results_json: JsonArrayView) -> tuple[int, int]:
     """Compute stats over snapshot files as identified by their hex digest.
 
     There may be duplicate hex digests within nodes for multiple copies of the same data chunks.
@@ -19,13 +30,16 @@ def compute_deduplicated_snapshot_file_stats(manifest: ipc.BackupManifest) -> tu
     """
     hexdigest_max_counts: dict[str, int] = {}
     hexdigest_sizes: dict[str, int] = {}
-    for snapshot_result in manifest.snapshot_results:
-        assert snapshot_result.state is not None
+    for snapshot_result in iter_objects(snapshot_results_json):
+        state = get_optional_object(snapshot_result, "state")
+        assert state is not None
         node_hexdigest_counter: defaultdict[str, int] = defaultdict(lambda: 0)
-        for snapshot_file in snapshot_result.state.files:
-            node_hexdigest_counter[snapshot_file.hexdigest] += 1
-            if snapshot_file.hexdigest not in hexdigest_sizes:
-                hexdigest_sizes[snapshot_file.hexdigest] = snapshot_file.file_size
+        for snapshot_file in iter_objects(get_array(state, "files")):
+            hexdigest = get_str(snapshot_file, "hexdigest", "")
+            file_size = get_int(snapshot_file, "file_size")
+            node_hexdigest_counter[hexdigest] += 1
+            if hexdigest not in hexdigest_sizes:
+                hexdigest_sizes[hexdigest] = file_size
         for hexdigest, count in node_hexdigest_counter.items():
             max_count = hexdigest_max_counts.get(hexdigest, 0)
             hexdigest_max_counts[hexdigest] = max(max_count, count)
@@ -39,19 +53,26 @@ def _iter_backups(storage: JsonStorage, backup_prefix: str) -> Iterator[ipc.List
         if not name.startswith(backup_prefix):
             continue
         pname = name[len(backup_prefix) :]
-        manifest = ipc.BackupManifest.parse_obj(storage.download_json(name))
-        files = sum(x.files for x in manifest.snapshot_results)
-        total_size = sum(x.total_size for x in manifest.snapshot_results)
-        upload_size = sum(x.total_size for x in manifest.upload_results)
-        upload_stored_size = sum(x.total_stored_size for x in manifest.upload_results)
-        cluster_files, cluster_data_size = compute_deduplicated_snapshot_file_stats(manifest)
+        manifest_json = storage.download_json(name)
+        assert isinstance(manifest_json, dict)
+        snapshot_results_json = get_array(manifest_json, "snapshot_results")
+        upload_results_json = get_array(manifest_json, "upload_results")
+        files = sum(get_int(x, "files", 0) for x in iter_objects(snapshot_results_json))
+        total_size = sum(get_int(x, "total_size", 0) for x in iter_objects(snapshot_results_json))
+        upload_size = sum(get_int(x, "total_size", 0) for x in iter_objects(upload_results_json))
+        upload_stored_size = sum(get_int(x, "total_stored_size", 0) for x in iter_objects(upload_results_json))
+        cluster_files, cluster_data_size = compute_deduplicated_snapshot_file_stats(snapshot_results_json)
+        start = parse_datetime(get_str(manifest_json, "start"))
+        maybe_end = get_optional_str(manifest_json, "end", None)
+        # The default value is odd, but that's what is defined in `ipc.BackupManifest`.
+        end = parse_datetime(maybe_end) if maybe_end is not None else now()
         yield ipc.ListSingleBackup(
             name=pname,
-            start=manifest.start,
-            end=manifest.end,
-            plugin=manifest.plugin,
-            attempt=manifest.attempt,
-            nodes=len(manifest.snapshot_results),
+            start=start,
+            end=end,
+            plugin=ipc.Plugin(get_str(manifest_json, "plugin")),
+            attempt=get_int(manifest_json, "attempt"),
+            nodes=len(snapshot_results_json),
             files=files,
             cluster_files=cluster_files,
             total_size=total_size,

--- a/astacus/coordinator/plugins/clickhouse/file_metadata.py
+++ b/astacus/coordinator/plugins/clickhouse/file_metadata.py
@@ -6,7 +6,6 @@ When using remote storage disk in ClickHouse, the actual data is in object stora
 but there are still metadata files in local storage. This module contains functions
 required to parse these metadata files.
 """
-from pathlib import Path
 from typing import Sequence
 
 import dataclasses
@@ -37,7 +36,7 @@ class InvalidFileMetadata(ValueError):
 @dataclasses.dataclass(frozen=True)
 class ObjectMetadata:
     size_bytes: int
-    relative_path: Path
+    relative_path: str
 
 
 @dataclasses.dataclass(frozen=True)
@@ -55,7 +54,7 @@ class FileMetadata:
         objects_metadata = [
             ObjectMetadata(
                 size_bytes=int(object_match.group("size_bytes")),
-                relative_path=Path(object_match.group("relative_path").decode()),
+                relative_path=object_match.group("relative_path").decode(),
             )
             for object_match in OBJECT_METADATA_RE.finditer(file_match.group("objects"))
         ]

--- a/astacus/coordinator/plugins/clickhouse/manifest.py
+++ b/astacus/coordinator/plugins/clickhouse/manifest.py
@@ -5,7 +5,6 @@ See LICENSE for details
 from astacus.common.utils import AstacusModel
 from astacus.coordinator.plugins.clickhouse.client import escape_sql_identifier
 from base64 import b64decode, b64encode
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from uuid import UUID
 
@@ -96,11 +95,11 @@ class ClickHouseBackupVersion(enum.Enum):
 
 
 class ClickHouseObjectStorageFile(AstacusModel):
-    path: Path
+    path: str
 
     @classmethod
     def from_plugin_data(cls, data: dict[str, Any]) -> "ClickHouseObjectStorageFile":
-        return ClickHouseObjectStorageFile(path=Path(data["path"]))
+        return ClickHouseObjectStorageFile(path=data["path"])
 
 
 class ClickHouseObjectStorageFiles(AstacusModel):

--- a/astacus/coordinator/plugins/clickhouse/steps.py
+++ b/astacus/coordinator/plugins/clickhouse/steps.py
@@ -38,7 +38,6 @@ from astacus.coordinator.plugins.base import (
 )
 from astacus.coordinator.plugins.zookeeper import ChangeWatch, TransactionError, ZooKeeperClient
 from base64 import b64decode
-from pathlib import Path
 from typing import Any, Awaitable, Callable, cast, Dict, Iterable, Iterator, List, Mapping, Sequence, Tuple, TypeVar
 
 import asyncio
@@ -236,7 +235,7 @@ class CollectObjectStorageFilesStep(Step[list[ClickHouseObjectStorageFiles]]):
 
     async def run_step(self, cluster: Cluster, context: StepsContext) -> list[ClickHouseObjectStorageFiles]:
         snapshot_results: Sequence[ipc.SnapshotResult] = context.get_result(SnapshotStep)
-        object_storage_files: dict[str, set[Path]] = {}
+        object_storage_files: dict[str, set[str]] = {}
         for snapshot_result in snapshot_results:
             assert snapshot_result.state is not None
             for snapshot_file in snapshot_result.state.files:
@@ -796,7 +795,7 @@ class DeleteDanglingObjectStorageFilesStep(Step[None]):
             return
         newest_backup_start_time = max((backup_manifest.start for backup_manifest in backup_manifests))
 
-        kept_paths: dict[str, set[Path]] = {}
+        kept_paths: dict[str, set[str]] = {}
         for manifest_min in backup_manifests:
             manifest_data = await download_backup_manifest(self.json_storage, manifest_min.filename)
             clickhouse_manifest = ClickHouseManifest.from_plugin_data(manifest_data.plugin_data)

--- a/astacus/node/snapshot.py
+++ b/astacus/node/snapshot.py
@@ -23,7 +23,7 @@ class Snapshot(ABC):
         ...
 
     @abstractmethod
-    def get_file(self, relative_path: Path) -> SnapshotFile | None:
+    def get_file(self, relative_path: str) -> SnapshotFile | None:
         ...
 
     @abstractmethod
@@ -34,7 +34,7 @@ class Snapshot(ABC):
     def get_all_files(self) -> Iterable[SnapshotFile]:
         ...
 
-    def get_all_paths(self) -> Iterable[Path]:
+    def get_all_paths(self) -> Iterable[str]:
         return (file.relative_path for file in self.get_all_files())
 
     @abstractmethod

--- a/astacus/node/snapshot_groups.py
+++ b/astacus/node/snapshot_groups.py
@@ -28,8 +28,8 @@ class CompiledGroup:
     def compile(cls, group: SnapshotGroup) -> Self:
         return cls(group, glob_compile(group.root_glob))
 
-    def matches(self, relative_path: Path) -> bool:
-        return bool(self.regex.match(str(relative_path))) and relative_path.name not in self.group.excluded_names
+    def matches(self, relative_path: str) -> bool:
+        return bool(self.regex.match(relative_path)) and relative_path.rpartition("/")[2] not in self.group.excluded_names
 
     def glob(self, root_dir: Optional[Path] = None) -> Iterable[str]:
         for path in iglob(self.group.root_glob, root_dir=root_dir, flags=WCMATCH_FLAGS):
@@ -45,10 +45,10 @@ class CompiledGroups:
     def compile(cls, groups: Sequence[SnapshotGroup]) -> Self:
         return cls([CompiledGroup.compile(group) for group in groups])
 
-    def get_matching(self, relative_path: Path) -> list[SnapshotGroup]:
+    def get_matching(self, relative_path: str) -> list[SnapshotGroup]:
         return [group.group for group in self.groups if group.matches(relative_path)]
 
-    def any_match(self, relative_path: Path) -> bool:
+    def any_match(self, relative_path: str) -> bool:
         return any(group.matches(relative_path) for group in self.groups)
 
     def root_globs(self) -> list[str]:

--- a/astacus/node/snapshotter.py
+++ b/astacus/node/snapshotter.py
@@ -47,7 +47,7 @@ class Snapshotter(ABC, Generic[T]):
     def get_snapshot_state(self) -> SnapshotState:
         return SnapshotState(root_globs=self._groups.root_globs(), files=list(self.snapshot.get_all_files()))
 
-    def _file_in_src(self, relative_path: Path) -> SnapshotFile:
+    def _file_in_src(self, relative_path: str) -> SnapshotFile:
         src_path = self._src / relative_path
         st = src_path.stat()
         return SnapshotFile(relative_path=relative_path, mtime_ns=st.st_mtime_ns, file_size=st.st_size)
@@ -77,7 +77,7 @@ class Snapshotter(ABC, Generic[T]):
                 raise ValueError("All SnapshotGroups containing a common file must have the same embedded_file_size_max")
         return head.embedded_file_size_max
 
-    def _maybe_link(self, relpath: Path) -> None:
+    def _maybe_link(self, relpath: str) -> None:
         """Links the src to the dst if we are not in same root mode.
         If dst exists, it is unlinked first.
         """

--- a/tests/integration/coordinator/plugins/clickhouse/test_file_metadata.py
+++ b/tests/integration/coordinator/plugins/clickhouse/test_file_metadata.py
@@ -3,7 +3,6 @@ Copyright (c) 2023 Aiven Ltd
 See LICENSE for details
 """
 from astacus.coordinator.plugins.clickhouse.file_metadata import FileMetadata, InvalidFileMetadata, ObjectMetadata
-from pathlib import Path
 
 import pytest
 
@@ -12,8 +11,8 @@ def test_file_metadata_from_bytes() -> None:
     expected = FileMetadata(
         metadata_version=3,
         objects=[
-            ObjectMetadata(size_bytes=100, relative_path=Path("abc/0123456789abcdef")),
-            ObjectMetadata(size_bytes=200, relative_path=Path("def/aaaaaaaaaaaaaaaa")),
+            ObjectMetadata(size_bytes=100, relative_path="abc/0123456789abcdef"),
+            ObjectMetadata(size_bytes=200, relative_path="def/aaaaaaaaaaaaaaaa"),
         ],
         ref_count=1,
         read_only=False,

--- a/tests/unit/common/test_json_view.py
+++ b/tests/unit/common/test_json_view.py
@@ -1,0 +1,316 @@
+"""
+Copyright (c) 2024 Aiven Ltd
+See LICENSE for details
+"""
+from astacus.common.json_view import (
+    get_any,
+    get_array,
+    get_bool,
+    get_float,
+    get_int,
+    get_object,
+    get_optional_bool,
+    get_optional_float,
+    get_optional_int,
+    get_optional_object,
+    get_optional_str,
+    get_str,
+    iter_objects,
+    JsonObjectView,
+    JsonParseError,
+    JsonView,
+    Undefined,
+)
+from collections import ChainMap
+from collections.abc import Sequence
+from types import MappingProxyType
+
+import pytest
+
+
+def test_iter_objects_accepts_a_list_of_dicts() -> None:
+    assert list(iter_objects([{}, {}])) == [{}, {}]
+
+
+def test_iter_objects_accepts_a_tuple_of_dicts() -> None:
+    assert list(iter_objects(({}, {}))) == [{}, {}]
+
+
+def test_iter_objects_accepts_a_list_of_other_mappings() -> None:
+    other_mappings: Sequence[JsonObjectView] = [ChainMap(), MappingProxyType({})]
+    assert list(iter_objects(other_mappings)) == other_mappings
+
+
+def test_iter_objects_rejects_a_non_dict_in_the_list() -> None:
+    with pytest.raises(JsonParseError, match="Unexpected type at index 1: expected Mapping, got int"):
+        list(iter_objects([{}, 123, {}]))
+
+
+def test_get_array_accepts_a_list() -> None:
+    assert get_array({"data": [{"key": "value"}]}, "data") == [{"key": "value"}]
+
+
+def test_get_array_accepts_a_tuple() -> None:
+    assert get_array({"data": ({"key": "value"},)}, "data") == ({"key": "value"},)
+
+
+def test_get_array_rejects_a_non_list() -> None:
+    with pytest.raises(JsonParseError, match="Unexpected type for data: expected Sequence, got int"):
+        list(get_array({"data": 123}, "data"))
+
+
+def test_get_array_rejects_a_missing_key() -> None:
+    with pytest.raises(JsonParseError, match="Missing key in object: data"):
+        list(get_array({}, "data"))
+
+
+def test_get_array_accepts_a_missing_key_if_passed_a_default() -> None:
+    assert list(get_array({}, "data", [{"key": "value"}])) == [{"key": "value"}]
+
+
+@pytest.mark.parametrize("mapping", [{}, ChainMap(), MappingProxyType({})])
+def test_get_object_accepts_any_mapping(mapping: JsonObjectView) -> None:
+    assert get_object({"data": mapping}, "data") == mapping
+
+
+def test_get_object_rejects_a_non_mapping() -> None:
+    with pytest.raises(JsonParseError, match="Unexpected type for data: expected Mapping, got int"):
+        get_object({"data": 123}, "data")
+
+
+def test_get_object_rejects_a_missing_key() -> None:
+    with pytest.raises(JsonParseError, match="Missing key in object: data"):
+        get_object({}, "data")
+
+
+def test_get_object_accepts_a_missing_key_if_passed_a_default() -> None:
+    assert get_object({}, "data", {"key": "value"}) == {"key": "value"}
+
+
+def test_get_str_accepts_a_str() -> None:
+    assert get_str({"data": "hello"}, "data") == "hello"
+
+
+def test_get_str_rejects_a_non_str() -> None:
+    with pytest.raises(JsonParseError, match="Unexpected type for data: expected str, got int"):
+        get_str({"data": 123}, "data")
+
+
+def test_get_str_rejects_a_missing_key() -> None:
+    with pytest.raises(JsonParseError, match="Missing key in object: data"):
+        get_str({}, "data")
+
+
+def test_get_str_accepts_a_missing_key_if_passed_a_default() -> None:
+    assert get_str({}, "data", "hello") == "hello"
+
+
+def test_get_int_accepts_an_int() -> None:
+    assert get_int({"data": 123}, "data") == 123
+
+
+def test_get_int_rejects_a_non_int() -> None:
+    with pytest.raises(JsonParseError, match="Unexpected type for data: expected int, got str"):
+        get_int({"data": "hello"}, "data")
+
+
+def test_get_int_rejects_a_bool() -> None:
+    with pytest.raises(JsonParseError, match="Unexpected type for data: expected int, got bool"):
+        get_int({"data": False}, "data")
+
+
+def test_get_int_rejects_a_default_bool() -> None:
+    with pytest.raises(ValueError, match="Unexpected type for default value, expected int or Undefined, got bool"):
+        get_int({"data": 123}, "data", default=False)
+
+
+def test_get_int_rejects_a_missing_key() -> None:
+    with pytest.raises(JsonParseError, match="Missing key in object: data"):
+        get_int({}, "data")
+
+
+def test_get_int_accepts_a_missing_key_if_passed_a_default() -> None:
+    assert get_int({}, "data", 123) == 123
+
+
+def test_get_float_accepts_a_float() -> None:
+    assert get_float({"data": 123.0}, "data") == 123.0
+
+
+def test_get_float_accepts_an_int() -> None:
+    assert get_float({"data": 123}, "data") == 123.0
+
+
+def test_get_float_rejects_a_non_float() -> None:
+    with pytest.raises(JsonParseError, match="Unexpected type for data: expected float, got str"):
+        get_float({"data": "hello"}, "data")
+
+
+def test_get_float_rejects_a_missing_key() -> None:
+    with pytest.raises(JsonParseError, match="Missing key in object: data"):
+        get_float({}, "data")
+
+
+def test_get_float_accepts_a_missing_key_if_passed_a_default_float() -> None:
+    assert get_float({}, "data", 123.0) == 123.0
+
+
+def test_get_float_accepts_a_missing_key_if_passed_a_default_int() -> None:
+    assert get_float({}, "data", 123) == 123.0
+
+
+def test_get_bool_accepts_an_bool() -> None:
+    assert get_bool({"data": True}, "data") is True
+
+
+def test_get_bool_rejects_a_non_bool() -> None:
+    with pytest.raises(JsonParseError, match="Unexpected type for data: expected bool, got str"):
+        get_bool({"data": "hello"}, "data")
+
+
+def test_get_bool_rejects_a_missing_key() -> None:
+    with pytest.raises(JsonParseError, match="Missing key in object: data"):
+        get_bool({}, "data")
+
+
+def test_get_bool_accepts_a_missing_key_if_passed_a_default() -> None:
+    assert get_bool({}, "data", True) is True
+
+
+@pytest.mark.parametrize("mapping", [{}, ChainMap(), MappingProxyType({})])
+def test_get_optional_object_accepts_a_mapping(mapping: JsonObjectView) -> None:
+    assert get_optional_object({"data": mapping}, "data") == mapping
+
+
+def test_get_optional_object_accepts_a_none() -> None:
+    assert get_optional_object({"data": None}, "data") is None
+
+
+def test_get_optional_object_accepts_a_missing_key() -> None:
+    assert get_optional_object({}, "data") is None
+
+
+def test_get_optional_object_rejects_a_missing_key_if_passed_undefined() -> None:
+    with pytest.raises(JsonParseError, match="Missing key in object: data"):
+        get_optional_object({}, "data", Undefined.undef)
+
+
+def test_get_optional_object_rejects_a_non_object() -> None:
+    with pytest.raises(JsonParseError, match="Unexpected type for data: expected Mapping or None, got int"):
+        get_optional_object({"data": 123}, "data")
+
+
+def test_get_optional_bool_accepts_a_bool() -> None:
+    assert get_optional_bool({"data": True}, "data") is True
+
+
+def test_get_optional_bool_accepts_a_none() -> None:
+    assert get_optional_bool({"data": None}, "data") is None
+
+
+def test_get_optional_bool_accepts_a_missing_key() -> None:
+    assert get_optional_bool({}, "data") is None
+
+
+def test_get_optional_bool_rejects_a_missing_key_if_passed_undefined() -> None:
+    with pytest.raises(JsonParseError, match="Missing key in object: data"):
+        get_optional_bool({}, "data", Undefined.undef)
+
+
+def test_get_optional_bool_rejects_a_non_bool() -> None:
+    with pytest.raises(JsonParseError, match="Unexpected type for data: expected bool or None, got int"):
+        get_optional_bool({"data": 123}, "data")
+
+
+def test_get_optional_str_accepts_a_str() -> None:
+    assert get_optional_str({"data": "hello"}, "data") == "hello"
+
+
+def test_get_optional_str_accepts_a_none() -> None:
+    assert get_optional_str({"data": None}, "data") is None
+
+
+def test_get_optional_str_accepts_a_missing_key() -> None:
+    assert get_optional_str({}, "data") is None
+
+
+def test_get_optional_str_rejects_a_missing_key_if_passed_undefined() -> None:
+    with pytest.raises(JsonParseError, match="Missing key in object: data"):
+        get_optional_str({}, "data", Undefined.undef)
+
+
+def test_get_optional_str_rejects_a_non_str() -> None:
+    with pytest.raises(JsonParseError, match="Unexpected type for data: expected str or None, got int"):
+        get_optional_str({"data": 123}, "data")
+
+
+def test_get_optional_int_accepts_a_int() -> None:
+    assert get_optional_int({"data": 123}, "data") == 123
+
+
+def test_get_optional_int_accepts_a_none() -> None:
+    assert get_optional_int({"data": None}, "data") is None
+
+
+def test_get_optional_int_accepts_a_missing_key() -> None:
+    assert get_optional_int({}, "data") is None
+
+
+def test_get_optional_int_rejects_a_missing_key_if_passed_undefined() -> None:
+    with pytest.raises(JsonParseError, match="Missing key in object: data"):
+        get_optional_int({}, "data", Undefined.undef)
+
+
+def test_get_optional_int_rejects_a_non_int() -> None:
+    with pytest.raises(JsonParseError, match="Unexpected type for data: expected int or None, got str"):
+        get_optional_int({"data": "hello"}, "data")
+
+
+def test_get_optional_int_rejects_a_bool() -> None:
+    with pytest.raises(JsonParseError, match="Unexpected type for data: expected int or None, got bool"):
+        get_optional_int({"data": False}, "data")
+
+
+def test_get_optional_int_rejects_a_default_bool() -> None:
+    with pytest.raises(ValueError, match="Unexpected type for default value, expected int, None or Undefined, got bool"):
+        get_optional_int({"data": 123}, "data", default=False)
+
+
+def test_get_optional_float_accepts_a_float() -> None:
+    assert get_optional_float({"data": 123.0}, "data") == 123.0
+
+
+def test_get_optional_float_accepts_an_int() -> None:
+    assert get_optional_float({"data": 123}, "data") == 123.0
+
+
+def test_get_optional_float_accepts_a_none() -> None:
+    assert get_optional_float({"data": None}, "data") is None
+
+
+def test_get_optional_float_accepts_a_missing_key() -> None:
+    assert get_optional_float({}, "data") is None
+
+
+def test_get_optional_float_rejects_a_missing_key_if_passed_undefined() -> None:
+    with pytest.raises(JsonParseError, match="Missing key in object: data"):
+        get_optional_float({}, "data", Undefined.undef)
+
+
+def test_get_optional_float_rejects_a_non_float() -> None:
+    with pytest.raises(JsonParseError, match="Unexpected type for data: expected float or None, got str"):
+        get_optional_float({"data": "hello"}, "data")
+
+
+def test_get_any_accepts_a_defined_key() -> None:
+    assert get_any({"data": 123}, "data") == 123
+
+
+def test_get_any_rejects_a_missing_key() -> None:
+    with pytest.raises(JsonParseError, match="Missing key in object: data"):
+        get_any({}, "data")
+
+
+@pytest.mark.parametrize("default", (None, 123, "hellp"))
+def test_get_any_accepts_a_missing_key_if_passed_a_default(default: JsonView) -> None:
+    assert get_any({}, "data", default) == default

--- a/tests/unit/coordinator/plugins/clickhouse/test_disks.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_disks.py
@@ -44,7 +44,7 @@ def test_get_snapshot_groups_pattern_escapes_backup_name() -> None:
 
 def test_parse_part_file_path() -> None:
     disks = Disks()
-    parsed_path = disks.parse_part_file_path(Path("store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt"))
+    parsed_path = disks.parse_part_file_path("store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt")
     assert parsed_path == ParsedPath(
         disk=Disk(type=DiskType.local, name="default", path_parts=()),
         freeze_name=None,
@@ -58,7 +58,7 @@ def test_parse_part_file_path() -> None:
 def test_parse_detached_part_file_path() -> None:
     disks = Disks()
     parsed_path = disks.parse_part_file_path(
-        Path("store/123/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt")
+        "store/123/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt"
     )
     assert parsed_path == ParsedPath(
         disk=Disk(type=DiskType.local, name="default", path_parts=()),
@@ -73,7 +73,7 @@ def test_parse_detached_part_file_path() -> None:
 def test_parse_shadow_part_file_path() -> None:
     disks = Disks()
     parsed_path = disks.parse_part_file_path(
-        Path("shadow/astacus/store/123/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt")
+        "shadow/astacus/store/123/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt"
     )
     assert parsed_path == ParsedPath(
         disk=Disk(type=DiskType.local, name="default", path_parts=()),
@@ -93,7 +93,7 @@ def test_parse_part_file_path_on_other_disk() -> None:
         ]
     )
     parsed_path = disks.parse_part_file_path(
-        Path("disks/secondary/store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt")
+        "disks/secondary/store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt"
     )
     assert parsed_path == ParsedPath(
         disk=Disk(type=DiskType.object_storage, name="secondary", path_parts=("disks", "secondary")),
@@ -108,69 +108,81 @@ def test_parse_part_file_path_on_other_disk() -> None:
 def test_parse_part_file_path_matching_no_disk() -> None:
     disks = Disks(disks=[Disk(type=DiskType.local, name="non_default", path_parts=("disks", "non_default"))])
     with pytest.raises(PartFilePathError, match="should start with a disk path"):
-        disks.parse_part_file_path(Path("store/123/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt"))
+        disks.parse_part_file_path("store/123/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt")
 
 
 def test_parse_part_file_path_not_in_store_or_shadow() -> None:
     disks = Disks()
     with pytest.raises(PartFilePathError, match="should start with 'store' or 'shadow' after the disk path"):
-        disks.parse_part_file_path(Path("config/config.xml"))
+        disks.parse_part_file_path("config/config.xml")
 
 
 def test_parse_part_file_path_invalid_uuid() -> None:
     disks = Disks()
     with pytest.raises(PartFilePathError, match="invalid table UUID"):
-        disks.parse_part_file_path(Path("store/123/12345678-XXXX-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt"))
+        disks.parse_part_file_path("store/123/12345678-XXXX-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt")
 
 
 def test_parse_part_file_path_consistent_uuid() -> None:
     disks = Disks()
     with pytest.raises(PartFilePathError, match="the UUID folder should have the 3 first characters of the UUID"):
-        disks.parse_part_file_path(Path("store/999/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt"))
+        disks.parse_part_file_path("store/999/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt")
 
 
 def test_parsed_path_to_path() -> None:
-    assert ParsedPath(
-        disk=Disk(type=DiskType.local, name="default", path_parts=()),
-        freeze_name=None,
-        table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
-        detached=False,
-        part_name=b"all_1_1_0",
-        file_parts=("checksum.txt",),
-    ).to_path() == Path("store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt")
+    assert (
+        ParsedPath(
+            disk=Disk(type=DiskType.local, name="default", path_parts=()),
+            freeze_name=None,
+            table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
+            detached=False,
+            part_name=b"all_1_1_0",
+            file_parts=("checksum.txt",),
+        ).to_path()
+        == "store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt"
+    )
 
 
 def test_detached_parsed_path_to_path() -> None:
-    assert ParsedPath(
-        disk=Disk(type=DiskType.local, name="default", path_parts=()),
-        freeze_name=None,
-        table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
-        detached=True,
-        part_name=b"all_1_1_0",
-        file_parts=("checksum.txt",),
-    ).to_path() == Path("store/123/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt")
+    assert (
+        ParsedPath(
+            disk=Disk(type=DiskType.local, name="default", path_parts=()),
+            freeze_name=None,
+            table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
+            detached=True,
+            part_name=b"all_1_1_0",
+            file_parts=("checksum.txt",),
+        ).to_path()
+        == "store/123/12345678-1234-1234-1234-12345678abcd/detached/all_1_1_0/checksum.txt"
+    )
 
 
 def test_shadow_parsed_path_to_path() -> None:
-    assert ParsedPath(
-        disk=Disk(type=DiskType.local, name="default", path_parts=()),
-        freeze_name=b"this/is\x80weird",
-        table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
-        detached=False,
-        part_name=b"all_1_1_0",
-        file_parts=("checksum.txt",),
-    ).to_path() == Path("shadow/this%2Fis%80weird/store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt")
+    assert (
+        ParsedPath(
+            disk=Disk(type=DiskType.local, name="default", path_parts=()),
+            freeze_name=b"this/is\x80weird",
+            table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
+            detached=False,
+            part_name=b"all_1_1_0",
+            file_parts=("checksum.txt",),
+        ).to_path()
+        == "shadow/this%2Fis%80weird/store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt"
+    )
 
 
 def test_other_disk_parsed_path_to_path() -> None:
-    assert ParsedPath(
-        disk=Disk(type=DiskType.object_storage, name="secondary", path_parts=("disks", "secondary")),
-        freeze_name=None,
-        table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
-        detached=False,
-        part_name=b"all_1_1_0",
-        file_parts=("checksum.txt",),
-    ).to_path() == Path("disks/secondary/store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt")
+    assert (
+        ParsedPath(
+            disk=Disk(type=DiskType.object_storage, name="secondary", path_parts=("disks", "secondary")),
+            freeze_name=None,
+            table_uuid=UUID("12345678-1234-1234-1234-12345678abcd"),
+            detached=False,
+            part_name=b"all_1_1_0",
+            file_parts=("checksum.txt",),
+        ).to_path()
+        == "disks/secondary/store/123/12345678-1234-1234-1234-12345678abcd/all_1_1_0/checksum.txt"
+    )
 
 
 def test_disk_can_load_default_object_storage_config() -> None:

--- a/tests/unit/coordinator/plugins/clickhouse/test_parts.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_parts.py
@@ -7,7 +7,6 @@ from astacus.coordinator.plugins.clickhouse.disks import Disks
 from astacus.coordinator.plugins.clickhouse.manifest import Table
 from astacus.coordinator.plugins.clickhouse.parts import get_part_servers, list_parts_to_attach, Part, PartFile
 from astacus.coordinator.plugins.clickhouse.replication import DatabaseReplica
-from pathlib import Path
 from typing import List
 from uuid import UUID
 
@@ -22,7 +21,7 @@ def create_part_files(*, table_uuid: UUID, part_name: str, digest_seed: str) -> 
     uuid_head = str(table_uuid)[:3]
     return [
         SnapshotFile(
-            relative_path=Path(f"store/{uuid_head}/{str(table_uuid)}/detached/{part_name}/{filename}"),
+            relative_path=f"store/{uuid_head}/{str(table_uuid)}/detached/{part_name}/{filename}",
             file_size=file_size,
             mtime_ns=0,
             hexdigest=hashlib.sha256(f"{digest_seed}-{part_name}-{filename}".encode()).hexdigest(),

--- a/tests/unit/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_steps.py
@@ -126,9 +126,9 @@ SAMPLE_OBJET_STORAGE_FILES = [
     ClickHouseObjectStorageFiles(
         disk_name="remote",
         files=[
-            ClickHouseObjectStorageFile(path=Path("abc/defghi")),
-            ClickHouseObjectStorageFile(path=Path("jkl/mnopqr")),
-            ClickHouseObjectStorageFile(path=Path("stu/vwxyza")),
+            ClickHouseObjectStorageFile(path="abc/defghi"),
+            ClickHouseObjectStorageFile(path="jkl/mnopqr"),
+            ClickHouseObjectStorageFile(path="stu/vwxyza"),
         ],
     )
 ]
@@ -407,10 +407,10 @@ async def test_retrieve_macros() -> None:
     ]
 
 
-def create_remote_file(path: Path, remote_path: Path) -> SnapshotFile:
+def create_remote_file(path: str, remote_path: str) -> SnapshotFile:
     metadata = f"""3\n1\t100\n100\t{remote_path}\n1\n0\n""".encode()
     return SnapshotFile(
-        relative_path=Path("disks/remote") / path,
+        relative_path=f"disks/remote/{path}",
         file_size=len(metadata),
         mtime_ns=1,
         content_b64=base64.b64encode(metadata).decode(),
@@ -434,12 +434,12 @@ async def test_collect_object_storage_file_steps() -> None:
                 root_globs=["dont", "care"],
                 files=[
                     create_remote_file(
-                        Path(f"store/{table_uuid_parts}/all_0_0_0/columns.txt"),
-                        Path("abc/defghi"),
+                        f"store/{table_uuid_parts}/all_0_0_0/columns.txt",
+                        "abc/defghi",
                     ),
                     create_remote_file(
-                        Path(f"store/{table_uuid_parts}/all_0_0_0/data.bin"),
-                        Path("jkl/mnopqr"),
+                        f"store/{table_uuid_parts}/all_0_0_0/data.bin",
+                        "jkl/mnopqr",
                     ),
                 ],
             )
@@ -449,12 +449,12 @@ async def test_collect_object_storage_file_steps() -> None:
                 root_globs=["dont", "care"],
                 files=[
                     create_remote_file(
-                        Path(f"store/{table_uuid_parts}/all_0_0_0/columns.txt"),
-                        Path("abc/defghi"),
+                        f"store/{table_uuid_parts}/all_0_0_0/columns.txt",
+                        "abc/defghi",
                     ),
                     create_remote_file(
-                        Path(f"store/{table_uuid_parts}/all_0_0_0/data.bin"),
-                        Path("stu/vwxyza"),
+                        f"store/{table_uuid_parts}/all_0_0_0/data.bin",
+                        "stu/vwxyza",
                     ),
                 ],
             )
@@ -481,14 +481,12 @@ async def test_move_frozen_parts_steps() -> None:
                 root_globs=["dont", "care"],
                 files=[
                     SnapshotFile(
-                        relative_path=Path(f"shadow/astacus/store/{table_uuid_parts}/detached/all_0_0_0/columns.txt"),
+                        relative_path=f"shadow/astacus/store/{table_uuid_parts}/detached/all_0_0_0/columns.txt",
                         file_size=100,
                         mtime_ns=1,
                     ),
                     SnapshotFile(
-                        relative_path=Path(
-                            f"disks/remote/shadow/astacus/store/{table_uuid_parts}/detached/all_0_0_0/data.bin"
-                        ),
+                        relative_path=f"disks/remote/shadow/astacus/store/{table_uuid_parts}/detached/all_0_0_0/data.bin",
                         file_size=100,
                         mtime_ns=1,
                     ),
@@ -503,12 +501,12 @@ async def test_move_frozen_parts_steps() -> None:
         root_globs=["dont", "care"],
         files=[
             SnapshotFile(
-                relative_path=Path(f"store/{table_uuid_parts}/all_0_0_0/columns.txt"),
+                relative_path=f"store/{table_uuid_parts}/all_0_0_0/columns.txt",
                 file_size=100,
                 mtime_ns=1,
             ),
             SnapshotFile(
-                relative_path=Path(f"disks/remote/store/{table_uuid_parts}/all_0_0_0/data.bin"),
+                relative_path=f"disks/remote/store/{table_uuid_parts}/all_0_0_0/data.bin",
                 file_size=100,
                 mtime_ns=1,
             ),
@@ -1071,12 +1069,12 @@ async def test_attaches_all_mergetree_parts_in_manifest() -> None:
                         root_globs=["dont", "care"],
                         files=[
                             SnapshotFile(
-                                relative_path=Path(f"store/000/{first_table_uuid}/detached/all_0_0_0/data.bin"),
+                                relative_path=f"store/000/{first_table_uuid}/detached/all_0_0_0/data.bin",
                                 file_size=0,
                                 mtime_ns=0,
                             ),
                             SnapshotFile(
-                                relative_path=Path(f"store/000/{second_table_uuid}/detached/all_1_1_0/data.bin"),
+                                relative_path=f"store/000/{second_table_uuid}/detached/all_1_1_0/data.bin",
                                 file_size=0,
                                 mtime_ns=0,
                             ),
@@ -1088,12 +1086,12 @@ async def test_attaches_all_mergetree_parts_in_manifest() -> None:
                         root_globs=["dont", "care"],
                         files=[
                             SnapshotFile(
-                                relative_path=Path(f"store/000/{first_table_uuid}/detached/all_0_0_0/data.bin"),
+                                relative_path=f"store/000/{first_table_uuid}/detached/all_0_0_0/data.bin",
                                 file_size=0,
                                 mtime_ns=0,
                             ),
                             SnapshotFile(
-                                relative_path=Path(f"store/000/{second_table_uuid}/detached/all_1_1_1/data.bin"),
+                                relative_path=f"store/000/{second_table_uuid}/detached/all_1_1_1/data.bin",
                                 file_size=0,
                                 mtime_ns=0,
                             ),
@@ -1156,19 +1154,13 @@ async def test_delete_object_storage_files_step(tmp_path: Path) -> None:
     object_storage = MemoryAsyncObjectStorage.from_items(
         [
             ObjectStorageItem(
-                key=Path("not_used/and_old"), last_modified=datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
+                key="not_used/and_old", last_modified=datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
             ),
+            ObjectStorageItem(key="abc/defghi", last_modified=datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)),
+            ObjectStorageItem(key="jkl/mnopqr", last_modified=datetime.datetime(2020, 1, 2, tzinfo=datetime.timezone.utc)),
+            ObjectStorageItem(key="stu/vwxyza", last_modified=datetime.datetime(2020, 1, 3, tzinfo=datetime.timezone.utc)),
             ObjectStorageItem(
-                key=Path("abc/defghi"), last_modified=datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)
-            ),
-            ObjectStorageItem(
-                key=Path("jkl/mnopqr"), last_modified=datetime.datetime(2020, 1, 2, tzinfo=datetime.timezone.utc)
-            ),
-            ObjectStorageItem(
-                key=Path("stu/vwxyza"), last_modified=datetime.datetime(2020, 1, 3, tzinfo=datetime.timezone.utc)
-            ),
-            ObjectStorageItem(
-                key=Path("not_used/and_new"), last_modified=datetime.datetime(2020, 1, 4, tzinfo=datetime.timezone.utc)
+                key="not_used/and_new", last_modified=datetime.datetime(2020, 1, 4, tzinfo=datetime.timezone.utc)
             ),
         ]
     )
@@ -1186,8 +1178,8 @@ async def test_delete_object_storage_files_step(tmp_path: Path) -> None:
                     ClickHouseObjectStorageFiles(
                         disk_name="remote",
                         files=[
-                            ClickHouseObjectStorageFile(path=Path("abc/defghi")),
-                            ClickHouseObjectStorageFile(path=Path("jkl/mnopqr")),
+                            ClickHouseObjectStorageFile(path="abc/defghi"),
+                            ClickHouseObjectStorageFile(path="jkl/mnopqr"),
                         ],
                     )
                 ],
@@ -1207,8 +1199,8 @@ async def test_delete_object_storage_files_step(tmp_path: Path) -> None:
                     ClickHouseObjectStorageFiles(
                         disk_name="remote",
                         files=[
-                            ClickHouseObjectStorageFile(path=Path("jkl/mnopqr")),
-                            ClickHouseObjectStorageFile(path=Path("stu/vwxyza")),
+                            ClickHouseObjectStorageFile(path="jkl/mnopqr"),
+                            ClickHouseObjectStorageFile(path="stu/vwxyza"),
                         ],
                     )
                 ],
@@ -1225,12 +1217,10 @@ async def test_delete_object_storage_files_step(tmp_path: Path) -> None:
     await step.run_step(cluster, context)
     assert await object_storage.list_items() == [
         # Only not_used/and_old was deleted
-        ObjectStorageItem(key=Path("abc/defghi"), last_modified=datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)),
-        ObjectStorageItem(key=Path("jkl/mnopqr"), last_modified=datetime.datetime(2020, 1, 2, tzinfo=datetime.timezone.utc)),
-        ObjectStorageItem(key=Path("stu/vwxyza"), last_modified=datetime.datetime(2020, 1, 3, tzinfo=datetime.timezone.utc)),
-        ObjectStorageItem(
-            key=Path("not_used/and_new"), last_modified=datetime.datetime(2020, 1, 4, tzinfo=datetime.timezone.utc)
-        ),
+        ObjectStorageItem(key="abc/defghi", last_modified=datetime.datetime(2020, 1, 1, tzinfo=datetime.timezone.utc)),
+        ObjectStorageItem(key="jkl/mnopqr", last_modified=datetime.datetime(2020, 1, 2, tzinfo=datetime.timezone.utc)),
+        ObjectStorageItem(key="stu/vwxyza", last_modified=datetime.datetime(2020, 1, 3, tzinfo=datetime.timezone.utc)),
+        ObjectStorageItem(key="not_used/and_new", last_modified=datetime.datetime(2020, 1, 4, tzinfo=datetime.timezone.utc)),
     ]
 
 

--- a/tests/unit/coordinator/test_list.py
+++ b/tests/unit/coordinator/test_list.py
@@ -26,6 +26,7 @@ from pytest_mock import MockerFixture
 from tests.utils import create_rohmu_config
 
 import datetime
+import json
 import pytest
 
 
@@ -216,7 +217,9 @@ def fixture_backup_manifest() -> BackupManifest:
 
 def test_compute_deduplicated_snapshot_file_stats(backup_manifest: BackupManifest) -> None:
     """Test backup stats are computed correctly in the presence of duplicate snapshot files."""
-    num_files, total_size = compute_deduplicated_snapshot_file_stats(backup_manifest)
+    manifest_json = json.loads(backup_manifest.json())
+    snapshot_results_json = manifest_json["snapshot_results"]
+    num_files, total_size = compute_deduplicated_snapshot_file_stats(snapshot_results_json)
     assert (num_files, total_size) == (6, 6000)
 
 

--- a/tests/unit/coordinator/test_list.py
+++ b/tests/unit/coordinator/test_list.py
@@ -22,7 +22,6 @@ from astacus.coordinator import api
 from astacus.coordinator.list import compute_deduplicated_snapshot_file_stats, list_backups
 from fastapi.testclient import TestClient
 from os import PathLike
-from pathlib import Path
 from pytest_mock import MockerFixture
 from tests.utils import create_rohmu_config
 
@@ -121,26 +120,26 @@ def fixture_backup_manifest() -> BackupManifest:
                     files=[
                         # First table
                         SnapshotFile(
-                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000001/detached/all_0_0_0/data.bin"),
+                            relative_path="store/000/00000000-0000-0000-0000-100000000001/detached/all_0_0_0/data.bin",
                             file_size=1000,
                             mtime_ns=0,
                             hexdigest="1000",
                         ),
                         SnapshotFile(
-                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000001/detached/all_1_1_0/data.bin"),
+                            relative_path="store/000/00000000-0000-0000-0000-100000000001/detached/all_1_1_0/data.bin",
                             file_size=1000,
                             mtime_ns=0,
                             hexdigest="1110",
                         ),
                         SnapshotFile(
-                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000001/detached/all_1_0_0/data.bin"),
+                            relative_path="store/000/00000000-0000-0000-0000-100000000001/detached/all_1_0_0/data.bin",
                             file_size=1000,
                             mtime_ns=0,
                             hexdigest="1100",
                         ),
                         # Second table
                         SnapshotFile(
-                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000002/detached/all_0_0_0/data.bin"),
+                            relative_path="store/000/00000000-0000-0000-0000-100000000002/detached/all_0_0_0/data.bin",
                             file_size=1000,
                             mtime_ns=0,
                             hexdigest="2000",
@@ -163,33 +162,33 @@ def fixture_backup_manifest() -> BackupManifest:
                     files=[
                         # First table
                         SnapshotFile(
-                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000001/detached/all_0_0_0/data.bin"),
+                            relative_path="store/000/00000000-0000-0000-0000-100000000001/detached/all_0_0_0/data.bin",
                             file_size=1000,
                             mtime_ns=0,
                             hexdigest="1000",
                         ),
                         SnapshotFile(
-                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000001/detached/all_1_1_0/data.bin"),
+                            relative_path="store/000/00000000-0000-0000-0000-100000000001/detached/all_1_1_0/data.bin",
                             file_size=1000,
                             mtime_ns=0,
                             hexdigest="1110",
                         ),
                         # Second table
                         SnapshotFile(
-                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000002/detached/all_0_0_0/data.bin"),
+                            relative_path="store/000/00000000-0000-0000-0000-100000000002/detached/all_0_0_0/data.bin",
                             file_size=1000,
                             mtime_ns=0,
                             hexdigest="2000",
                         ),
                         SnapshotFile(
-                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000002/detached/all_1_1_0/data.bin"),
+                            relative_path="store/000/00000000-0000-0000-0000-100000000002/detached/all_1_1_0/data.bin",
                             file_size=1000,
                             mtime_ns=0,
                             hexdigest="2110",
                         ),
                         # Third table with same hexdigest as second one
                         SnapshotFile(
-                            relative_path=Path("store/000/00000000-0000-0000-0000-100000000003/detached/all_0_0_0/data.bin"),
+                            relative_path="store/000/00000000-0000-0000-0000-100000000003/detached/all_0_0_0/data.bin",
                             file_size=1000,
                             mtime_ns=0,
                             hexdigest="2000",

--- a/tests/unit/coordinator/test_restore.py
+++ b/tests/unit/coordinator/test_restore.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass
 from datetime import datetime, UTC
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from pathlib import Path
 from typing import Any, Callable, ContextManager, Optional
 
 import httpx
@@ -34,7 +33,7 @@ BACKUP_MANIFEST = ipc.BackupManifest(
         ipc.SnapshotResult(
             state=ipc.SnapshotState(
                 root_globs=["*"],
-                files=[ipc.SnapshotFile(relative_path=Path("foo"), file_size=6, mtime_ns=0, hexdigest="DEADBEEF")],
+                files=[ipc.SnapshotFile(relative_path="foo", file_size=6, mtime_ns=0, hexdigest="DEADBEEF")],
             ),
             hashes=[ipc.SnapshotHash(hexdigest="DEADBEEF", size=6)],
             files=1,

--- a/tests/unit/node/conftest.py
+++ b/tests/unit/node/conftest.py
@@ -112,7 +112,7 @@ def build_snapshot_and_snapshotter(
     return snapshot, snapshotter
 
 
-def create_files_at_path(dir_: Path, files: list[tuple[Path, bytes]]) -> None:
+def create_files_at_path(dir_: Path, files: list[tuple[str, bytes]]) -> None:
     for relpath, content in files:
         path = dir_ / relpath
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/node/test_node_download.py
+++ b/tests/unit/node/test_node_download.py
@@ -33,10 +33,10 @@ def test_download(
     create_files_at_path(
         src,
         [
-            (Path("foo"), b"foo"),
-            (Path("foo2"), b"foo2"),
-            (Path("foobig"), b"foobig" * magic.DEFAULT_EMBEDDED_FILE_SIZE),
-            (Path("foobig2"), b"foobig2" * magic.DEFAULT_EMBEDDED_FILE_SIZE),
+            ("foo", b"foo"),
+            ("foo2", b"foo2"),
+            ("foobig", b"foobig" * magic.DEFAULT_EMBEDDED_FILE_SIZE),
+            ("foobig2", b"foobig2" * magic.DEFAULT_EMBEDDED_FILE_SIZE),
         ],
     )
     snapshot, snapshotter = build_snapshot_and_snapshotter(src, dst, db, SQLiteSnapshot, [SnapshotGroup("**")])

--- a/tests/unit/node/test_node_snapshot.py
+++ b/tests/unit/node/test_node_snapshot.py
@@ -41,10 +41,10 @@ def test_snapshot(
         create_files_at_path(
             src,
             [
-                (Path("foo"), b"foo"),
-                (Path("foo2"), b"foo2"),
-                (Path("foobig"), b"foobig" * magic.DEFAULT_EMBEDDED_FILE_SIZE),
-                (Path("foobig2"), b"foobig2" * magic.DEFAULT_EMBEDDED_FILE_SIZE),
+                ("foo", b"foo"),
+                ("foo2", b"foo2"),
+                ("foobig", b"foobig" * magic.DEFAULT_EMBEDDED_FILE_SIZE),
+                ("foobig2", b"foobig2" * magic.DEFAULT_EMBEDDED_FILE_SIZE),
             ],
         )
         snapshotter.perform_snapshot(progress=Progress())
@@ -66,7 +66,7 @@ def test_snapshot(
         while True:
             (src / "foo").write_text("barfoo")  # same length
             snapshotter.perform_snapshot(progress=Progress())
-            if snapshot.get_file(Path("foo")) is not None:
+            if snapshot.get_file("foo") is not None:
                 # Sometimes fails on first iteration(s) due to same mtime
                 # (inaccurate timestamps)
                 break

--- a/tests/unit/node/test_snapshot_groups.py
+++ b/tests/unit/node/test_snapshot_groups.py
@@ -10,21 +10,21 @@ from pathlib import Path
 
 import os
 
-POSITIVE_TEST_CASES: list[tuple[Path, str]] = [
-    (Path("foo"), "foo"),
-    (Path("foo"), "*"),
-    (Path("foo/bar"), "*/bar"),
-    (Path("foo"), "**"),
-    (Path("foo/bar"), "**"),
-    (Path("foo/bar/baz"), "**/*"),
-    (Path("foo/bar"), "**/*"),
-    (Path("foo/bar"), "**/**"),
+POSITIVE_TEST_CASES: list[tuple[str, str]] = [
+    ("foo", "foo"),
+    ("foo", "*"),
+    ("foo/bar", "*/bar"),
+    ("foo", "**"),
+    ("foo/bar", "**"),
+    ("foo/bar/baz", "**/*"),
+    ("foo/bar", "**/*"),
+    ("foo/bar", "**/**"),
 ]
 
-NEGATIVE_TEST_CASES: list[tuple[Path, str]] = [
-    (Path("foo/bar/baz"), "*/*"),
-    (Path("foo"), "foobar"),
-    (Path("foo"), "*/foo"),
+NEGATIVE_TEST_CASES: list[tuple[str, str]] = [
+    ("foo/bar/baz", "*/*"),
+    ("foo", "foobar"),
+    ("foo", "*/foo"),
 ]
 
 
@@ -58,9 +58,9 @@ def test_CompiledGroups() -> None:
 
 def test_CompiledGroup_glob(tmp_path: Path) -> None:
     for p, _ in POSITIVE_TEST_CASES + NEGATIVE_TEST_CASES:
-        p = tmp_path / p
-        p.mkdir(parents=True, exist_ok=True)
-        p.touch()
+        absolute_p = tmp_path / p
+        absolute_p.mkdir(parents=True, exist_ok=True)
+        absolute_p.touch()
     for p, glob in POSITIVE_TEST_CASES:
         group = SnapshotGroup(root_glob=glob)
         assert str(p) in CompiledGroup.compile(group).glob(tmp_path)

--- a/tests/unit/node/test_snapshotter.py
+++ b/tests/unit/node/test_snapshotter.py
@@ -25,9 +25,9 @@ def test_snapshotter(src: Path, dst: Path, db: Path, src_is_dst: bool) -> None:
         SnapshotGroup(root_glob="folder2/*c", embedded_file_size_max=None),
     ]
     snapshot, snapshotter = build_snapshot_and_snapshotter(src, dst, db, SQLiteSnapshot, groups)
-    matched_under_embedded_file_size_max = [(Path("folder1") / "aaa", b"aaaaa"), (Path("folder2") / "ccc", b"ccccc")]
-    matched_over_embedded_file_size_max = [(Path("bbb"), b"bbbbb")]
-    not_matched = [(Path("ddd"), b"ddddd"), (Path("eee"), b"eeeee")]
+    matched_under_embedded_file_size_max = [("folder1/aaa", b"aaaaa"), ("folder2/ccc", b"ccccc")]
+    matched_over_embedded_file_size_max = [("bbb", b"bbbbb")]
+    not_matched = [("ddd", b"ddddd"), ("eee", b"eeeee")]
     create_files_at_path(src, matched_under_embedded_file_size_max + matched_over_embedded_file_size_max + not_matched)
     snapshotter.perform_snapshot(progress=Progress())
     assert len(snapshot) == 3
@@ -59,7 +59,7 @@ def test_snapshotter(src: Path, dst: Path, db: Path, src_is_dst: bool) -> None:
 @pytest.mark.parametrize("src_is_dst", [True, False])
 @pytest.mark.parametrize("new_file_size", [1024, 2048])
 @pytest.mark.parametrize("embedded_file_size_max", [None, 1, 1500, 3000])
-@pytest.mark.parametrize("path", [Path("abc123"), Path("folder") / "abc123"])
+@pytest.mark.parametrize("path", ["abc123", "folder/abc123"])
 def test_snapshotter_updates_changed_file(
     src: Path,
     dst: Path,
@@ -67,7 +67,7 @@ def test_snapshotter_updates_changed_file(
     src_is_dst: bool,
     new_file_size: int,
     embedded_file_size_max: int,
-    path: Path,
+    path: str,
 ) -> None:
     if src_is_dst:
         dst = src
@@ -101,8 +101,8 @@ def test_snapshotter_updates_changed_file(
 
 
 @pytest.mark.parametrize("src_is_dst", [True, False])
-@pytest.mark.parametrize("path", [Path("abc123"), Path("folder") / "abc123"])
-def test_snapshotter_removes_removed_file(src: Path, dst: Path, db: Path, src_is_dst: bool, path: Path) -> None:
+@pytest.mark.parametrize("path", ["abc123", "folder/abc123"])
+def test_snapshotter_removes_removed_file(src: Path, dst: Path, db: Path, src_is_dst: bool, path: str) -> None:
     if src_is_dst:
         dst = src
     create_files_at_path(src, [(path, b"abc123")])
@@ -118,8 +118,8 @@ def test_snapshotter_removes_removed_file(src: Path, dst: Path, db: Path, src_is
 
 
 def test_snapshotter_release_hash_unlinks_files_but_keeps_metadata(src: Path, dst: Path, db: Path) -> None:
-    keep = Path("keep_this")
-    release = Path("release_this")
+    keep = "keep_this"
+    release = "release_this"
     create_files_at_path(src, [(keep, b"this will be kept")])
     create_files_at_path(dst, [(keep, b"this will be kept")])
     create_files_at_path(src, [(release, b"this will be released")])


### PR DESCRIPTION
This is not the optimal solution (splitting files, changing the manifest format, etc.)

But profiling shows significant reduction in memory usage for large manifests with these changes, without breaking backward compatibility:

- use `str` instead of `Path` wherever possible. The `Path` API is nice, but  the abstraction is too expensive when we have a large number of objects.
- only convert to `pydantic` models the subset of data that we care about, for instance if we want a single snapshot in an entire manifest, don't convert the entire manifest, just the single snapshot.
- `list_backups`: stay completely in json-land, but with type-safe accessors to read the data.

Tested on a large 800MiB manifest, peak usage during `list_backups` was reduced from ~8GiB to ~4.1GiB and lasted for a much shorter time.