### PR TITLE
cassandra: drop nodes from cluster when they are stopped

### DIFF
--- a/astacus/coordinator/plugins/cassandra/plugin.py
+++ b/astacus/coordinator/plugins/cassandra/plugin.py
@@ -174,7 +174,9 @@ class CassandraPlugin(CoordinatorPlugin):
                 partial_restore_nodes=req.partial_restore_nodes,
             ),
             restore_steps.StartCassandraStep(replace_backup_nodes=True, override_tokens=True, cassandra_nodes=self.nodes),
-            restore_steps.WaitCassandraUpStep(duration=self.restore_start_timeout),
+            restore_steps.WaitCassandraUpStep(
+                duration=self.restore_start_timeout, replaced_node_step=restore_steps.StopReplacedNodesStep
+            ),
         ]
 
     def get_restore_schema_from_manifest_steps(

--- a/astacus/coordinator/plugins/cassandra/utils.py
+++ b/astacus/coordinator/plugins/cassandra/utils.py
@@ -41,10 +41,12 @@ async def run_subop(
     return await cluster.wait_successful_results(start_results=start_results, result_class=result_class)
 
 
-async def get_schema_hash(cluster: Cluster) -> Tuple[str, str]:
+async def get_schema_hash(cluster: Cluster, nodes: Optional[list[CoordinatorNode]] = None) -> Tuple[str, str]:
     hashes = [
         x.schema_hash
-        for x in await run_subop(cluster, ipc.CassandraSubOp.get_schema_hash, result_class=ipc.CassandraGetSchemaHashResult)
+        for x in await run_subop(
+            cluster, ipc.CassandraSubOp.get_schema_hash, result_class=ipc.CassandraGetSchemaHashResult, nodes=nodes
+        )
     ]
     if not hashes:
         return "", "Unable to retrieve schema hash at all"

--- a/tests/unit/coordinator/plugins/cassandra/conftest.py
+++ b/tests/unit/coordinator/plugins/cassandra/conftest.py
@@ -4,6 +4,14 @@ See LICENSE for details
 """
 
 
+from astacus.coordinator.plugins.base import StepsContext
 from tests.utils import is_cassandra_driver_importable
 
+import pytest
+
 collect_ignore_glob = [] if is_cassandra_driver_importable() else ["*.py"]
+
+
+@pytest.fixture(name="context")
+def fixture_context() -> StepsContext:
+    return StepsContext()

--- a/tests/unit/coordinator/plugins/cassandra/test_utils.py
+++ b/tests/unit/coordinator/plugins/cassandra/test_utils.py
@@ -45,5 +45,5 @@ async def test_run_subop(mocker: MockerFixture, start_ok: bool) -> None:
 @pytest.mark.asyncio
 async def test_get_schema_hash(mocker: MockerFixture, hashes: list[int], result: tuple[str, str]) -> None:
     mocker.patch.object(utils, "run_subop", return_value=[Mock(schema_hash=hash) for hash in hashes])
-    actual_result = await utils.get_schema_hash(mocker.Mock())
+    actual_result = await utils.get_schema_hash(mocker.Mock(nodes=[]))
     assert actual_result == result


### PR DESCRIPTION


cassandra is going to try and contact these stopped nodes to get hashes
from them, but that is bound to fail as the cassandra there has been
stopped. This only delays the whole restore step and causes un-necessary
timouts and various places.