### PR TITLE
replace pydantic with msgspec for ipc [DDB-881]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,3 +55,4 @@ repos:
           - typing_extensions>=3.10.0
           - msgspec==0.18.6
           - pydantic==1.10.9
+          - starlette==0.27.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,4 +53,5 @@ repos:
           - types-ujson>=5.9.0.0
           - types-urllib3>=1.26.25.4
           - typing_extensions>=3.10.0
+          - msgspec==0.18.6
           - pydantic==1.10.9

--- a/astacus/client.py
+++ b/astacus/client.py
@@ -5,13 +5,13 @@ See LICENSE for details
 Client commands for Astacus tool
 
 """
-
 from astacus.common import ipc, magic, utils
 from astacus.common.utils import exponential_backoff, http_request
 from tabulate import tabulate
 
 import json as _json
 import logging
+import msgspec
 import time
 
 logger = logging.getLogger(__name__)
@@ -142,17 +142,17 @@ def _run_list(args, list_path: str) -> bool:
     r = http_request(f"{args.url}/{list_path}{storage_name}", caller="client._run_list")
     if r is None:
         return False
-    print_list_result(ipc.ListResponse.parse_obj(r))
+    print_list_result(msgspec.convert(r, ipc.ListResponse))
     return True
 
 
 def _run_cleanup(args) -> bool:
     json = {}  # type: ignore
     # Copy retention fields from argparser arguments to the json request, if set
-    for k in ipc.Retention().dict().keys():
-        v = getattr(args, k, None)
+    for field in msgspec.structs.fields(ipc.Retention):
+        v = getattr(args, field.encode_name, None)
         if v:
-            json.setdefault("retention", {})[k] = v
+            json.setdefault("retention", {})[field.encode_name] = v
     return _run_op("cleanup", args, json=json)
 
 

--- a/astacus/common/asyncstorage.py
+++ b/astacus/common/asyncstorage.py
@@ -5,8 +5,7 @@ See LICENSE for details
 
 """
 
-from astacus.common.storage import HexDigestStorage, Json, JsonStorage
-from astacus.common.utils import AstacusModel
+from astacus.common.storage import HexDigestStorage, JsonStorage
 from starlette.concurrency import run_in_threadpool
 
 
@@ -44,11 +43,8 @@ class AsyncJsonStorage:
     async def delete_json(self, name: str) -> None:
         return await run_in_threadpool(self.storage.delete_json, name)
 
-    async def download_json(self, name: str) -> Json:
-        return await run_in_threadpool(self.storage.download_json, name)
-
     async def list_jsons(self) -> list[str]:
         return await run_in_threadpool(self.storage.list_jsons)
 
-    async def upload_json(self, name: str, data: AstacusModel | Json) -> bool:
-        return await run_in_threadpool(self.storage.upload_json, name, data)
+    async def upload_json_bytes(self, name: str, data: bytes) -> bool:
+        return await run_in_threadpool(self.storage.upload_json_bytes, name, data)

--- a/astacus/common/cachingjsonstorage.py
+++ b/astacus/common/cachingjsonstorage.py
@@ -21,9 +21,12 @@ assumption is that backups are immutable, that is, if file backup-X
 exists, its contents stay the same.
 
 """
-
 from .exceptions import NotFoundException
-from .storage import Json, JsonStorage, MultiStorage
+from .storage import JsonStorage, MultiStorage
+from collections.abc import Iterator
+
+import contextlib
+import mmap
 
 
 class CachingJsonStorage(JsonStorage):
@@ -58,25 +61,27 @@ class CachingJsonStorage(JsonStorage):
         self.backend_storage.delete_json(name)
         self._backend_json_set_remove(name)
 
-    def download_json(self, name: str) -> Json:
+    @contextlib.contextmanager
+    def open_json_bytes(self, name: str) -> Iterator[mmap.mmap]:
         if name not in self._backend_json_set:
             raise NotFoundException()
         try:
-            return self.cache_storage.download_json(name)
+            with self.cache_storage.open_json_bytes(name) as json_bytes:
+                yield json_bytes
         except NotFoundException:
-            pass
-        data = self.backend_storage.download_json(name)
-        self.cache_storage.upload_json(name, data)
-        return data
+            with self.backend_storage.open_json_bytes(name) as json_bytes:
+                self.cache_storage.upload_json_bytes(name, json_bytes)
+            with self.cache_storage.open_json_bytes(name) as json_bytes:
+                yield json_bytes
 
     def list_jsons(self) -> list[str]:
         if self._backend_json_list is None:
             self._backend_json_list = sorted(self._backend_json_set)
         return self._backend_json_list
 
-    def upload_json_str(self, name: str, data: str) -> bool:
-        self.cache_storage.upload_json_str(name, data)
-        self.backend_storage.upload_json_str(name, data)
+    def upload_json_bytes(self, name: str, data: bytes | mmap.mmap) -> bool:
+        self.cache_storage.upload_json_bytes(name, data)
+        self.backend_storage.upload_json_bytes(name, data)
         self._backend_json_set_add(name)
         return True
 

--- a/astacus/common/ipc.py
+++ b/astacus/common/ipc.py
@@ -4,15 +4,16 @@ See LICENSE for details
 """
 from .magic import DEFAULT_EMBEDDED_FILE_SIZE, StrEnum
 from .progress import Progress
-from .utils import AstacusModel, now, SizeLimitedFile
+from .utils import now, SizeLimitedFile
 from astacus.common.snapshot import SnapshotGroup
 from collections.abc import Sequence, Set
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from pydantic import Field, root_validator
+from typing import Self
 
 import functools
+import msgspec
 import socket
 
 # pydantic validators are class methods in disguise
@@ -38,7 +39,7 @@ class NodeFeatures(Enum):
     release_snapshot_files = "release_snapshot_files"
 
 
-class Retention(AstacusModel):
+class Retention(msgspec.Struct, kw_only=True):
     # If set, number of backups to retain always (even beyond days)
     minimum_backups: int | None = None
 
@@ -53,26 +54,26 @@ class Retention(AstacusModel):
 # node generic base
 
 
-class NodeRequest(AstacusModel):
+class NodeRequest(msgspec.Struct, kw_only=True):
     result_url: str = ""  # where results are sent
 
 
-class NodeResult(AstacusModel):
-    hostname: str = Field(default_factory=socket.gethostname)
+class NodeResult(msgspec.Struct, kw_only=True):
+    hostname: str = msgspec.field(default_factory=socket.gethostname)
     az: str = ""
-    progress: Progress = Field(default_factory=Progress)
+    progress: Progress = msgspec.field(default_factory=Progress)
 
 
-class MetadataResult(AstacusModel):
+class MetadataResult(msgspec.Struct, kw_only=True):
     version: str
-    features: Sequence[str] = Field(default_factory=list)
+    features: Sequence[str] = msgspec.field(default_factory=list)
 
 
 # node.snapshot
 
 
 @functools.total_ordering
-class SnapshotFile(AstacusModel):
+class SnapshotFile(msgspec.Struct, kw_only=True, omit_defaults=True):
     relative_path: str
     file_size: int
     mtime_ns: int
@@ -87,15 +88,20 @@ class SnapshotFile(AstacusModel):
         return self.mtime_ns == o.mtime_ns and self.relative_path == o.relative_path and self.file_size == o.file_size
 
     def equals_excluding_mtime(self, o: "SnapshotFile") -> bool:
-        return self.copy(update={"mtime_ns": 0}) == o.copy(update={"mtime_ns": 0})
+        return (self.relative_path, self.file_size, self.hexdigest, self.content_b64) == (
+            o.relative_path,
+            o.file_size,
+            o.hexdigest,
+            o.content_b64,
+        )
 
     def open_for_reading(self, root_path: Path) -> SizeLimitedFile:
         return SizeLimitedFile(path=root_path / self.relative_path, file_size=self.file_size)
 
 
-class SnapshotState(AstacusModel):
-    root_globs: Sequence[str] = []
-    files: Sequence[SnapshotFile] = []
+class SnapshotState(msgspec.Struct, kw_only=True, omit_defaults=True):
+    root_globs: Sequence[str] = msgspec.field(default_factory=list)
+    files: Sequence[SnapshotFile] = msgspec.field(default_factory=list)
 
 
 class SnapshotRequest(NodeRequest):
@@ -103,7 +109,7 @@ class SnapshotRequest(NodeRequest):
     root_globs: Sequence[str] = ()
 
 
-class SnapshotRequestGroup(AstacusModel):
+class SnapshotRequestGroup(msgspec.Struct, kw_only=True):
     root_glob: str
     # Exclude some file names that matched the glob
     excluded_names: Sequence[str] = ()
@@ -138,7 +144,7 @@ def create_snapshot_request(
     )
 
 
-class SnapshotHash(AstacusModel):
+class SnapshotHash(msgspec.Struct, kw_only=True, frozen=True):
     """
     This class represents something that is to be stored in the object storage.
 
@@ -174,21 +180,21 @@ class SnapshotUploadRequestV20221129(SnapshotUploadRequest):
     validate_file_hashes: bool = True
 
 
-class SnapshotUploadResult(NodeResult):
+class SnapshotUploadResult(NodeResult, kw_only=True):
     total_size: int = 0
     total_stored_size: int = 0
 
 
 class SnapshotResult(NodeResult):
     # when was the operation started ( / done )
-    start: datetime = Field(default_factory=now)
+    start: datetime = msgspec.field(default_factory=now)
     end: datetime | None = None
 
     # The state is optional because it's written by the Snapshotter post-initialization.
     # If the backup failed, the related manifest doesn't exist: the state and the
     # summary attributes below will be set to none and their default values respectively.
     # Should be passed opaquely to restore.
-    state: SnapshotState | None = Field(default_factory=SnapshotState)
+    state: SnapshotState | None = msgspec.field(default_factory=SnapshotState)
 
     # Summary data for manifest use
     files: int = 0
@@ -260,19 +266,19 @@ class CassandraRestoreSSTablesRequest(NodeRequest):
 
 
 # coordinator.api
-class PartialRestoreRequestNode(AstacusModel):
+class PartialRestoreRequestNode(msgspec.Struct, kw_only=True):
+    def __post_init__(self) -> None:
+        if (self.backup_index is None) == (self.backup_hostname is None):
+            raise ValueError("Exactly one of backup_index or backup_hostname supported")
+        if (self.node_index is None) == (self.node_url is None):
+            raise ValueError("Exactly one of node_index or node_url supported")
+
     # One of these has to be specified
     #
     # index = index in configuration
     # hostname = hostname of the host that did the backup
     backup_index: int | None = None
     backup_hostname: str | None = None
-
-    @root_validator
-    def _check_only_one_backup_criteria(cls, values):
-        if (values["backup_index"] is None) == (values["backup_hostname"] is None):
-            raise ValueError("Exactly one of backup_index or backup_hostname supported")
-        return values
 
     # One of these has to be specified
     #
@@ -281,14 +287,8 @@ class PartialRestoreRequestNode(AstacusModel):
     node_index: int | None = None
     node_url: str | None = None
 
-    @root_validator
-    def _check_only_one_node_criteria(cls, values):
-        if (values["node_index"] is None) == (values["node_url"] is None):
-            raise ValueError("Exactly one of node_index or node_url supported")
-        return values
 
-
-class RestoreRequest(AstacusModel):
+class RestoreRequest(msgspec.Struct, kw_only=True):
     storage: str = ""
     name: str = ""
     partial_restore_nodes: Sequence[PartialRestoreRequestNode] | None = None
@@ -296,12 +296,12 @@ class RestoreRequest(AstacusModel):
 
 
 # coordinator.plugins backup/restore
-class BackupManifest(AstacusModel):
+class BackupManifest(msgspec.Struct, kw_only=True):
     # When was (this) backup attempt started
     start: datetime
 
     # .. and when did it finish
-    end: datetime = Field(default_factory=now)
+    end: datetime = msgspec.field(default_factory=now)
 
     # How many attempts did it take (starts from 1)
     attempt: int
@@ -316,20 +316,30 @@ class BackupManifest(AstacusModel):
     plugin: Plugin
 
     # Plugin-specific data about the backup
-    plugin_data: dict = {}
+    plugin_data: dict = msgspec.field(default_factory=dict)
 
     # Semi-redundant but simplifies handling; automatically set on download
     filename: str = ""
 
 
+class ManifestMin(msgspec.Struct, kw_only=True):
+    start: datetime
+    end: datetime
+    filename: str
+
+    @classmethod
+    def from_manifest(cls, manifest: BackupManifest) -> Self:
+        return cls(start=manifest.start, end=manifest.end, filename=manifest.filename)
+
+
 # coordinator.list
 
 
-class ListRequest(AstacusModel):
+class ListRequest(msgspec.Struct, kw_only=True):
     storage: str = ""
 
 
-class ListSingleBackup(AstacusModel):
+class ListSingleBackup(msgspec.Struct, kw_only=True):
     # Subset of BackupManifest; see it for information
     name: str
     start: datetime
@@ -348,19 +358,19 @@ class ListSingleBackup(AstacusModel):
     cluster_data_size: int
 
 
-class ListForStorage(AstacusModel):
+class ListForStorage(msgspec.Struct, kw_only=True):
     storage_name: str
     backups: Sequence[ListSingleBackup]
 
 
-class ListResponse(AstacusModel):
+class ListResponse(msgspec.Struct, kw_only=True):
     storages: Sequence[ListForStorage]
 
 
 # coordinator.cleanup
 
 
-class CleanupRequest(AstacusModel):
+class CleanupRequest(msgspec.Struct, kw_only=True):
     storage: str = ""
     retention: Retention | None = None
-    explicit_delete: Sequence[str] = []
+    explicit_delete: Sequence[str] = msgspec.field(default_factory=list)

--- a/astacus/common/msgspec_glue.py
+++ b/astacus/common/msgspec_glue.py
@@ -1,0 +1,34 @@
+"""
+Copyright (c) 2024 Aiven Ltd
+See LICENSE for details
+"""
+from pydantic import PydanticValueError
+from pydantic.fields import ModelField
+from pydantic.validators import _VALIDATORS
+from starlette.responses import JSONResponse
+from typing import Any
+
+import msgspec
+
+
+class MsgSpecError(PydanticValueError):
+    msg_template = "{value} is not a valid msgspec {type}"
+
+
+def validate_struct(v: Any, field: ModelField) -> msgspec.Struct:
+    if isinstance(v, msgspec.Struct) and isinstance(v, field.annotation):
+        return v
+    if isinstance(v, dict):
+        return msgspec.convert(v, field.annotation)
+    raise MsgSpecError(value=v, type=field.annotation)
+
+
+def register_msgspec_glue() -> None:
+    validator = (msgspec.Struct, [validate_struct])
+    if validator not in _VALIDATORS:
+        _VALIDATORS.append(validator)
+
+
+class StructResponse(JSONResponse):
+    def render(self, content: msgspec.Struct) -> bytes:
+        return msgspec.json.encode(content)

--- a/astacus/common/progress.py
+++ b/astacus/common/progress.py
@@ -4,13 +4,12 @@ Copyright (c) 2020 Aiven Ltd
 See LICENSE for details
 
 """
-
-from .utils import AstacusModel
 from pyparsing import Iterable
 from typing_extensions import Self, TypeVar
 
 import logging
 import math
+import msgspec
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +40,7 @@ def increase_worth_reporting(value: int, new_value: int | None = None, *, total:
 T = TypeVar("T")
 
 
-class Progress(AstacusModel):
+class Progress(msgspec.Struct, kw_only=True):
     """JSON-encodable progress meter of sorts"""
 
     handled: int = 0

--- a/astacus/coordinator/api.py
+++ b/astacus/coordinator/api.py
@@ -177,10 +177,8 @@ def op_status(*, op_name: OpName, op_id: int, c: Coordinator = Depends()):
 @router.put("/delta/{op_name}/{op_id}/sub-result")
 async def op_sub_result(*, op_name: OpName, op_id: int, c: Coordinator = Depends()):
     op, _ = c.get_op_and_op_info(op_id=op_id, op_name=op_name)
-    # Someday, we might want to actually store results. This is sort
-    # of spoofable endpoint though, so just triggering subsequent
-    # result fetching faster. In case of terminal results, this
-    # results only in one extra fetch per node, so not big deal.
+    # We used to have results available here, but not use those
+    # that was wasting a lot of memory by generating the same result twice.
     if not op.subresult_sleeper:
         return
     op.subresult_sleeper.wakeup()

--- a/astacus/coordinator/cleanup.py
+++ b/astacus/coordinator/cleanup.py
@@ -22,10 +22,21 @@ class CleanupOp(SteppedCoordinatorOp):
 
     def __init__(self, *, c: Coordinator, req: ipc.CleanupRequest) -> None:
         context = c.get_operation_context()
-        retention = c.config.retention.copy()
-        if req.retention is not None:
-            # This returns only non-defaults -> non-Nones
-            for k, v in req.retention.dict().items():
-                setattr(retention, k, v)
+        if req.retention is None:
+            retention = ipc.Retention(
+                minimum_backups=c.config.retention.minimum_backups,
+                maximum_backups=c.config.retention.maximum_backups,
+                keep_days=c.config.retention.keep_days,
+            )
+        else:
+            retention = ipc.Retention(
+                minimum_backups=coalesce(req.retention.minimum_backups, c.config.retention.minimum_backups),
+                maximum_backups=coalesce(req.retention.maximum_backups, c.config.retention.maximum_backups),
+                keep_days=coalesce(req.retention.keep_days, c.config.retention.keep_days),
+            )
         steps = c.get_plugin().get_cleanup_steps(context=context, retention=retention, explicit_delete=req.explicit_delete)
         super().__init__(c=c, attempts=1, steps=steps)
+
+
+def coalesce(a: int | None, b: int | None) -> int | None:
+    return a if a is not None else b

--- a/astacus/coordinator/config.py
+++ b/astacus/coordinator/config.py
@@ -41,8 +41,20 @@ class CoordinatorNode(AstacusModel):
     az: str = ""
 
 
+class Retention(AstacusModel):
+    # If set, number of backups to retain always (even beyond days)
+    minimum_backups: int | None = None
+
+    # If set, maximum number of backups to retain
+    maximum_backups: int | None = None
+
+    # Backups older than this are deleted, unless it would reduce
+    # number of backups to less than minimum_backups
+    keep_days: int | None = None
+
+
 class CoordinatorConfig(AstacusModel):
-    retention: ipc.Retention = ipc.Retention(keep_days=7, minimum_backups=3)
+    retention: Retention = Retention(keep_days=7, minimum_backups=3)
 
     poll: PollConfig = PollConfig()
 

--- a/astacus/coordinator/manifest.py
+++ b/astacus/coordinator/manifest.py
@@ -7,8 +7,20 @@ from starlette.concurrency import run_in_threadpool
 
 
 async def download_backup_manifest(json_storage: asyncstorage.AsyncJsonStorage, backup_name: str) -> ipc.BackupManifest:
-    d = await json_storage.download_json(backup_name)
-    manifest = await run_in_threadpool(ipc.BackupManifest.parse_obj, d)
+    def download_manifest() -> ipc.BackupManifest:
+        return json_storage.storage.download_json(backup_name, ipc.BackupManifest)
+
+    manifest = await run_in_threadpool(download_manifest)
+    assert not manifest.filename or manifest.filename == backup_name
+    manifest.filename = backup_name
+    return manifest
+
+
+async def download_backup_min_manifest(json_storage: asyncstorage.AsyncJsonStorage, backup_name: str) -> ipc.ManifestMin:
+    def download_min_manifest() -> ipc.ManifestMin:
+        return json_storage.storage.download_json(backup_name, ipc.ManifestMin)
+
+    manifest = await run_in_threadpool(download_min_manifest)
     assert not manifest.filename or manifest.filename == backup_name
     manifest.filename = backup_name
     return manifest

--- a/astacus/coordinator/plugins/cassandra/restore_steps.py
+++ b/astacus/coordinator/plugins/cassandra/restore_steps.py
@@ -29,6 +29,7 @@ from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 
 import logging
+import msgspec
 
 logger = logging.getLogger(__name__)
 
@@ -154,7 +155,7 @@ class UploadFinalDeltaStep(Step[Sequence[ipc.BackupManifest]]):
             filename=backup_name,
         )
         logger.info("Storing backup manifest %s", backup_name)
-        await self.json_storage.upload_json(backup_name, manifest)
+        await self.json_storage.upload_json_bytes(backup_name, msgspec.json.encode(manifest))
         return [manifest]
 
 

--- a/astacus/coordinator/plugins/clickhouse/steps.py
+++ b/astacus/coordinator/plugins/clickhouse/steps.py
@@ -405,17 +405,12 @@ class MoveFrozenPartsStep(Step[None]):
         snapshot_results: Sequence[ipc.SnapshotResult] = context.get_result(SnapshotStep)
         for snapshot_result in snapshot_results:
             assert snapshot_result.state is not None
-            snapshot_result.state.files = [
-                msgspec.structs.replace(
-                    snapshot_file,
-                    relative_path=dataclasses.replace(
-                        self.disks.parse_part_file_path(snapshot_file.relative_path),
-                        freeze_name=None,
-                        detached=False,
-                    ).to_path(),
-                )
-                for snapshot_file in snapshot_result.state.files
-            ]
+            for snapshot_file in snapshot_result.state.files:
+                snapshot_file.relative_path = msgspec.structs.replace(
+                    self.disks.parse_part_file_path(snapshot_file.relative_path),
+                    freeze_name=None,
+                    detached=False,
+                ).to_path()
 
 
 @dataclasses.dataclass

--- a/astacus/coordinator/plugins/clickhouse/steps.py
+++ b/astacus/coordinator/plugins/clickhouse/steps.py
@@ -45,6 +45,7 @@ import asyncio
 import base64
 import dataclasses
 import logging
+import msgspec
 import secrets
 import uuid
 
@@ -405,14 +406,13 @@ class MoveFrozenPartsStep(Step[None]):
         for snapshot_result in snapshot_results:
             assert snapshot_result.state is not None
             snapshot_result.state.files = [
-                snapshot_file.copy(
-                    update={
-                        "relative_path": dataclasses.replace(
-                            self.disks.parse_part_file_path(snapshot_file.relative_path),
-                            freeze_name=None,
-                            detached=False,
-                        ).to_path()
-                    }
+                msgspec.structs.replace(
+                    snapshot_file,
+                    relative_path=dataclasses.replace(
+                        self.disks.parse_part_file_path(snapshot_file.relative_path),
+                        freeze_name=None,
+                        detached=False,
+                    ).to_path(),
                 )
                 for snapshot_file in snapshot_result.state.files
             ]

--- a/astacus/coordinator/state.py
+++ b/astacus/coordinator/state.py
@@ -14,15 +14,15 @@ from astacus.common.op import OpState
 from astacus.coordinator.config import CoordinatorConfig
 from dataclasses import dataclass
 from fastapi import FastAPI, Request
-from pydantic import Field
 
+import msgspec
 import time
 
 APP_KEY = "coordinator_state"
 
 
-class CachedListResponse(utils.AstacusModel):
-    timestamp: float = Field(default_factory=time.monotonic)
+class CachedListResponse(msgspec.Struct, kw_only=True):
+    timestamp: float = msgspec.field(default_factory=time.monotonic)
     coordinator_config: CoordinatorConfig
     list_request: ipc.ListRequest
     list_response: ipc.ListResponse

--- a/astacus/node/api.py
+++ b/astacus/node/api.py
@@ -9,14 +9,16 @@ from .snapshot_op import ReleaseOp, SnapshotOp, UploadOp
 from .state import node_state, NodeState
 from astacus.common import ipc
 from astacus.common.magic import StrEnum
+from astacus.common.msgspec_glue import register_msgspec_glue, StructResponse
 from astacus.common.snapshot import SnapshotGroup
 from astacus.node.config import CassandraAccessLevel
 from astacus.node.snapshotter import Snapshotter
 from astacus.version import __version__
 from collections.abc import Sequence
-from fastapi import APIRouter, Depends, HTTPException
-from typing import TypeAlias
+from fastapi import APIRouter, Body, Depends, HTTPException
+from typing import Annotated, TypeAlias
 
+register_msgspec_glue()
 router = APIRouter()
 
 READONLY_SUBOPS = {
@@ -46,10 +48,12 @@ def is_allowed(subop: ipc.CassandraSubOp, access_level: CassandraAccessLevel):
 
 
 @router.get("/metadata")
-def metadata() -> ipc.MetadataResult:
-    return ipc.MetadataResult(
-        version=__version__,
-        features=[feature.value for feature in ipc.NodeFeatures],
+def metadata() -> StructResponse:
+    return StructResponse(
+        ipc.MetadataResult(
+            version=__version__,
+            features=[feature.value for feature in ipc.NodeFeatures],
+        )
     )
 
 
@@ -85,7 +89,17 @@ def unlock(locker: str, state: NodeState = Depends(node_state)):
 
 
 @router.post("/snapshot")
-def snapshot(req: ipc.SnapshotRequestV2, n: Node = Depends()):
+def snapshot(
+    groups: Annotated[Sequence[ipc.SnapshotRequestGroup], Body()],
+    result_url: Annotated[str, Body()] = "",
+    # Accept V1 request for backward compatibility if the controller is older
+    # root_globs: Annotated[Sequence[str], Body()],
+    n: Node = Depends(),
+):
+    req = ipc.SnapshotRequestV2(
+        result_url=result_url,
+        groups=groups,
+    )
     if not n.state.is_locked:
         raise HTTPException(status_code=409, detail="Not locked")
     snapshotter = snapshotter_from_snapshot_req(req, n)
@@ -93,13 +107,21 @@ def snapshot(req: ipc.SnapshotRequestV2, n: Node = Depends()):
 
 
 @router.get("/snapshot/{op_id}")
-def snapshot_result(*, op_id: int, n: Node = Depends()):
+def snapshot_result(*, op_id: int, n: Node = Depends()) -> StructResponse:
     op, _ = n.get_op_and_op_info(op_id=op_id, op_name=OpName.snapshot)
-    return op.result
+    return StructResponse(op.result)
 
 
 @router.post("/delta/snapshot")
-def delta_snapshot(req: ipc.SnapshotRequestV2, n: Node = Depends()):
+def delta_snapshot(
+    groups: Annotated[Sequence[ipc.SnapshotRequestGroup], Body()],
+    result_url: Annotated[str, Body()] = "",
+    n: Node = Depends(),
+):
+    req = ipc.SnapshotRequestV2(
+        result_url=result_url,
+        groups=groups,
+    )
     if not n.state.is_locked:
         raise HTTPException(status_code=409, detail="Not locked")
     snapshotter = delta_snapshotter_from_snapshot_req(req, n)
@@ -107,13 +129,25 @@ def delta_snapshot(req: ipc.SnapshotRequestV2, n: Node = Depends()):
 
 
 @router.get("/delta/snapshot/{op_id}")
-def delta_snapshot_result(*, op_id: int, n: Node = Depends()):
+def delta_snapshot_result(*, op_id: int, n: Node = Depends()) -> StructResponse:
     op, _ = n.get_op_and_op_info(op_id=op_id, op_name=OpName.snapshot)
-    return op.result
+    return StructResponse(op.result)
 
 
 @router.post("/upload")
-def upload(req: ipc.SnapshotUploadRequestV20221129, n: Node = Depends()):
+def upload(
+    hashes: Annotated[Sequence[ipc.SnapshotHash], Body()],
+    storage: Annotated[str, Body()],
+    validate_file_hashes: Annotated[bool, Body()] = True,
+    result_url: Annotated[str, Body()] = "",
+    n: Node = Depends(),
+):
+    req = ipc.SnapshotUploadRequestV20221129(
+        result_url=result_url,
+        hashes=hashes,
+        storage=storage,
+        validate_file_hashes=validate_file_hashes,
+    )
     if not n.state.is_locked:
         raise HTTPException(status_code=409, detail="Not locked")
     snapshot_ = n.get_or_create_snapshot()
@@ -121,13 +155,25 @@ def upload(req: ipc.SnapshotUploadRequestV20221129, n: Node = Depends()):
 
 
 @router.get("/upload/{op_id}")
-def upload_result(*, op_id: int, n: Node = Depends()):
+def upload_result(*, op_id: int, n: Node = Depends()) -> StructResponse:
     op, _ = n.get_op_and_op_info(op_id=op_id, op_name=OpName.upload)
-    return op.result
+    return StructResponse(op.result)
 
 
 @router.post("/delta/upload")
-def delta_upload(req: ipc.SnapshotUploadRequestV20221129, n: Node = Depends()):
+def delta_upload(
+    hashes: Annotated[Sequence[ipc.SnapshotHash], Body()],
+    storage: Annotated[str, Body()],
+    validate_file_hashes: Annotated[bool, Body()] = True,
+    result_url: Annotated[str, Body()] = "",
+    n: Node = Depends(),
+):
+    req = ipc.SnapshotUploadRequestV20221129(
+        result_url=result_url,
+        hashes=hashes,
+        storage=storage,
+        validate_file_hashes=validate_file_hashes,
+    )
     if not n.state.is_locked:
         raise HTTPException(status_code=409, detail="Not locked")
     snapshot_ = n.get_or_create_delta_snapshot()
@@ -135,13 +181,21 @@ def delta_upload(req: ipc.SnapshotUploadRequestV20221129, n: Node = Depends()):
 
 
 @router.get("/delta/upload/{op_id}")
-def delta_upload_result(*, op_id: int, n: Node = Depends()):
+def delta_upload_result(*, op_id: int, n: Node = Depends()) -> StructResponse:
     op, _ = n.get_op_and_op_info(op_id=op_id, op_name=OpName.upload)
-    return op.result
+    return StructResponse(op.result)
 
 
 @router.post("/release")
-def release(req: ipc.SnapshotReleaseRequest, n: Node = Depends()):
+def release(
+    hexdigests: Annotated[Sequence[str], Body()],
+    result_url: Annotated[str, Body()] = "",
+    n: Node = Depends(),
+):
+    req = ipc.SnapshotReleaseRequest(
+        result_url=result_url,
+        hexdigests=hexdigests,
+    )
     if not n.state.is_locked:
         raise HTTPException(status_code=409, detail="Not locked")
     # Groups not needed here.
@@ -151,13 +205,27 @@ def release(req: ipc.SnapshotReleaseRequest, n: Node = Depends()):
 
 
 @router.get("/release/{op_id}")
-def release_result(*, op_id: int, n: Node = Depends()):
+def release_result(*, op_id: int, n: Node = Depends()) -> StructResponse:
     op, _ = n.get_op_and_op_info(op_id=op_id, op_name=OpName.release)
-    return op.result
+    return StructResponse(op.result)
 
 
 @router.post("/download")
-def download(req: ipc.SnapshotDownloadRequest, n: Node = Depends()):
+def download(
+    storage: Annotated[str, Body()],
+    backup_name: Annotated[str, Body()],
+    snapshot_index: Annotated[int, Body()],
+    root_globs: Annotated[Sequence[str], Body()],
+    result_url: Annotated[str, Body()] = "",
+    n: Node = Depends(),
+):
+    req = ipc.SnapshotDownloadRequest(
+        result_url=result_url,
+        storage=storage,
+        backup_name=backup_name,
+        snapshot_index=snapshot_index,
+        root_globs=root_globs,
+    )
     if not n.state.is_locked:
         raise HTTPException(status_code=409, detail="Not locked")
     snapshotter = snapshotter_from_snapshot_req(req, n)
@@ -165,13 +233,27 @@ def download(req: ipc.SnapshotDownloadRequest, n: Node = Depends()):
 
 
 @router.get("/download/{op_id}")
-def download_result(*, op_id: int, n: Node = Depends()):
+def download_result(*, op_id: int, n: Node = Depends()) -> StructResponse:
     op, _ = n.get_op_and_op_info(op_id=op_id, op_name=OpName.download)
-    return op.result
+    return StructResponse(op.result)
 
 
 @router.post("/delta/download")
-def delta_download(req: ipc.SnapshotDownloadRequest, n: Node = Depends()):
+def delta_download(
+    storage: Annotated[str, Body()],
+    backup_name: Annotated[str, Body()],
+    snapshot_index: Annotated[int, Body()],
+    root_globs: Annotated[Sequence[str], Body()],
+    result_url: Annotated[str, Body()] = "",
+    n: Node = Depends(),
+):
+    req = ipc.SnapshotDownloadRequest(
+        result_url=result_url,
+        storage=storage,
+        backup_name=backup_name,
+        snapshot_index=snapshot_index,
+        root_globs=root_globs,
+    )
     if not n.state.is_locked:
         raise HTTPException(status_code=409, detail="Not locked")
     snapshotter = delta_snapshotter_from_snapshot_req(req, n)
@@ -179,13 +261,14 @@ def delta_download(req: ipc.SnapshotDownloadRequest, n: Node = Depends()):
 
 
 @router.get("/delta/download/{op_id}")
-def delta_download_result(*, op_id: int, n: Node = Depends()):
+def delta_download_result(*, op_id: int, n: Node = Depends()) -> StructResponse:
     op, _ = n.get_op_and_op_info(op_id=op_id, op_name=OpName.download)
-    return op.result
+    return StructResponse(op.result)
 
 
 @router.post("/clear")
-def clear(req: ipc.SnapshotClearRequest, n: Node = Depends()):
+def clear(root_globs: Annotated[Sequence[str], Body()], result_url: Annotated[str, Body()] = "", n: Node = Depends()):
+    req = ipc.SnapshotClearRequest(result_url=result_url, root_globs=root_globs)
     if not n.state.is_locked:
         raise HTTPException(status_code=409, detail="Not locked")
     snapshotter = snapshotter_from_snapshot_req(req, n)
@@ -193,13 +276,14 @@ def clear(req: ipc.SnapshotClearRequest, n: Node = Depends()):
 
 
 @router.get("/clear/{op_id}")
-def clear_result(*, op_id: int, n: Node = Depends()):
+def clear_result(*, op_id: int, n: Node = Depends()) -> StructResponse:
     op, _ = n.get_op_and_op_info(op_id=op_id, op_name=OpName.clear)
-    return op.result
+    return StructResponse(op.result)
 
 
 @router.post("/delta/clear")
-def delta_clear(req: ipc.SnapshotClearRequest, n: Node = Depends()):
+def delta_clear(root_globs: Annotated[Sequence[str], Body()], result_url: Annotated[str, Body()] = "", n: Node = Depends()):
+    req = ipc.SnapshotClearRequest(result_url=result_url, root_globs=root_globs)
     if not n.state.is_locked:
         raise HTTPException(status_code=409, detail="Not locked")
     snapshotter = delta_snapshotter_from_snapshot_req(req, n)
@@ -207,23 +291,77 @@ def delta_clear(req: ipc.SnapshotClearRequest, n: Node = Depends()):
 
 
 @router.get("/delta/clear/{op_id}")
-def delta_clear_result(*, op_id: int, n: Node = Depends()):
+def delta_clear_result(*, op_id: int, n: Node = Depends()) -> StructResponse:
     op, _ = n.get_op_and_op_info(op_id=op_id, op_name=OpName.clear)
-    return op.result
+    return StructResponse(op.result)
 
 
-@router.post("/cassandra/{subop}")
-def cassandra(
-    req: ipc.NodeRequest | ipc.CassandraStartRequest | ipc.CassandraRestoreSSTablesRequest,
-    subop: ipc.CassandraSubOp,
+@router.post("/cassandra/start-cassandra")
+def cassandra_start_cassandra(
+    tokens: Annotated[Sequence[str] | None, Body()] = None,
+    replace_address_first_boot: Annotated[str | None, Body()] = None,
+    skip_bootstrap_streaming: Annotated[bool | None, Body()] = None,
+    result_url: Annotated[str, Body()] = "",
     n: Node = Depends(),
 ):
+    req = ipc.CassandraStartRequest(
+        result_url=result_url,
+        tokens=tokens,
+        replace_address_first_boot=replace_address_first_boot,
+        skip_bootstrap_streaming=skip_bootstrap_streaming,
+    )
     # pylint: disable=import-outside-toplevel
     # pylint: disable=raise-missing-from
     try:
-        from .cassandra import CassandraGetSchemaHashOp, CassandraRestoreSSTablesOp, CassandraStartOp, SimpleCassandraSubOp
+        from .cassandra import CassandraStartOp
     except ImportError:
         raise HTTPException(status_code=501, detail="Cassandra support is not installed")
+    check_can_do_cassandra_subop(n, ipc.CassandraSubOp.start_cassandra)
+    return CassandraStartOp(n=n, op_id=n.allocate_op_id(), stats=n.stats, req=req).start()
+
+
+@router.post("/cassandra/restore-sstables")
+def cassandra_restore_sstables(
+    table_glob: Annotated[str, Body()],
+    keyspaces_to_skip: Annotated[Sequence[str], Body()],
+    match_tables_by: Annotated[ipc.CassandraTableMatching, Body()],
+    expect_empty_target: Annotated[bool, Body()],
+    result_url: Annotated[str, Body()] = "",
+    n: Node = Depends(),
+):
+    req = ipc.CassandraRestoreSSTablesRequest(
+        result_url=result_url,
+        table_glob=table_glob,
+        keyspaces_to_skip=keyspaces_to_skip,
+        match_tables_by=match_tables_by,
+        expect_empty_target=expect_empty_target,
+    )
+    # pylint: disable=import-outside-toplevel
+    # pylint: disable=raise-missing-from
+    try:
+        from .cassandra import CassandraRestoreSSTablesOp
+    except ImportError:
+        raise HTTPException(status_code=501, detail="Cassandra support is not installed")
+    check_can_do_cassandra_subop(n, ipc.CassandraSubOp.restore_sstables)
+    return CassandraRestoreSSTablesOp(n=n, op_id=n.allocate_op_id(), stats=n.stats, req=req).start()
+
+
+@router.post("/cassandra/{subop}")
+def cassandra(subop: ipc.CassandraSubOp, result_url: Annotated[str, Body(embed=True)] = "", n: Node = Depends()):
+    req = ipc.NodeRequest(result_url=result_url)
+    # pylint: disable=import-outside-toplevel
+    # pylint: disable=raise-missing-from
+    try:
+        from .cassandra import CassandraGetSchemaHashOp, SimpleCassandraSubOp
+    except ImportError:
+        raise HTTPException(status_code=501, detail="Cassandra support is not installed")
+    check_can_do_cassandra_subop(n, subop)
+    if subop == ipc.CassandraSubOp.get_schema_hash:
+        return CassandraGetSchemaHashOp(n=n, op_id=n.allocate_op_id(), stats=n.stats, req=req).start()
+    return SimpleCassandraSubOp(n=n, op_id=n.allocate_op_id(), stats=n.stats, req=req).start(subop=subop)
+
+
+def check_can_do_cassandra_subop(n: Node, subop: ipc.CassandraSubOp) -> None:
     if not n.state.is_locked:
         raise HTTPException(status_code=409, detail="Not locked")
     if not n.config.cassandra:
@@ -234,24 +372,11 @@ def cassandra(
             detail=f"Cassandra subop {subop} is not allowed on access level {n.config.cassandra.access_level}",
         )
 
-    if subop == ipc.CassandraSubOp.get_schema_hash:
-        return CassandraGetSchemaHashOp(n=n, op_id=n.allocate_op_id(), stats=n.stats, req=req).start()
-
-    if subop == ipc.CassandraSubOp.start_cassandra:
-        assert isinstance(req, ipc.CassandraStartRequest)
-        return CassandraStartOp(n=n, op_id=n.allocate_op_id(), stats=n.stats, req=req).start()
-
-    if subop == ipc.CassandraSubOp.restore_sstables:
-        assert isinstance(req, ipc.CassandraRestoreSSTablesRequest)
-        return CassandraRestoreSSTablesOp(n=n, op_id=n.allocate_op_id(), stats=n.stats, req=req).start()
-
-    return SimpleCassandraSubOp(n=n, op_id=n.allocate_op_id(), stats=n.stats, req=req).start(subop=subop)
-
 
 @router.get("/cassandra/{subop}/{op_id}")
-def cassandra_result(*, subop: ipc.CassandraSubOp, op_id: int, n: Node = Depends()):
+def cassandra_result(*, subop: ipc.CassandraSubOp, op_id: int, n: Node = Depends()) -> StructResponse:
     op, _ = n.get_op_and_op_info(op_id=op_id, op_name=OpName.cassandra)
-    return op.result
+    return StructResponse(op.result)
 
 
 SnapshotReq: TypeAlias = ipc.SnapshotRequestV2 | ipc.SnapshotDownloadRequest | ipc.SnapshotClearRequest

--- a/astacus/node/download.py
+++ b/astacus/node/download.py
@@ -12,17 +12,17 @@ API of this module with proper parameters.
 from .node import NodeOp
 from .snapshotter import Snapshotter
 from astacus.common import ipc, utils
-from astacus.common.json_view import get_array, get_object, iter_objects
 from astacus.common.progress import Progress
 from astacus.common.rohmustorage import RohmuStorage
 from astacus.common.storage import Storage, ThreadLocalStorage
 from astacus.common.utils import get_umask
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 import base64
 import getpass
 import logging
+import msgspec
 import os
 import shutil
 import subprocess
@@ -173,11 +173,9 @@ class DownloadOp(NodeOp[ipc.SnapshotDownloadRequest, ipc.NodeResult]):
     def download(self) -> None:
         assert self.snapshotter is not None
         # Actual 'restore from backup'
-        manifest_json = self.storage.download_json(self.req.backup_name)
-        assert isinstance(manifest_json, Mapping)
-        snapshot_results_json = list(iter_objects(get_array(manifest_json, "snapshot_results")))
-        snapshotstate_json = get_object(snapshot_results_json[self.req.snapshot_index], "state")
-        snapshotstate = ipc.SnapshotState.parse_obj(snapshotstate_json)
+        with self.storage.open_json_bytes(self.req.backup_name) as manifest_content:
+            manifest = msgspec.json.decode(manifest_content, type=ipc.BackupManifest)
+        snapshotstate = manifest.snapshot_results[self.req.snapshot_index].state
         assert snapshotstate is not None
 
         # 'snapshotter' is global; ensure we have sole access to it

--- a/astacus/node/node.py
+++ b/astacus/node/node.py
@@ -35,7 +35,6 @@ class NodeOp(op.Op, Generic[Request, Result]):
         self.start_op = n.start_op
         self.config = n.config
         self._still_locked_callback = n.state.still_locked_callback
-        self._sent_result_json: bytes | None = None
         self.req = req
         self.result = self.create_result()
         self.result.az = self.config.az
@@ -58,11 +57,15 @@ class NodeOp(op.Op, Generic[Request, Result]):
         if not self.still_running_callback():
             logger.debug("send_result omitted - not running")
             return
-        result_json = msgspec.json.encode(self.result)
-        if result_json == self._sent_result_json:
-            return
-        self._sent_result_json = result_json
-        utils.http_request(self.req.result_url, method="put", caller="NodeOp.send_result", data=result_json)
+        # We used to send the entire  json-encoded result but not use it, wasting a lot of memory for nothing
+        status = msgspec.json.encode(
+            ipc.NodeResult(
+                hostname=self.result.hostname,
+                az=self.result.az,
+                progress=self.result.progress,
+            )
+        )
+        utils.http_request(self.req.result_url, method="put", caller="NodeOp.send_result", data=status)
 
     def set_status(self, status: op.Op.Status, *, from_status: op.Op.Status | None = None) -> bool:
         if not super().set_status(status, from_status=from_status):

--- a/astacus/node/node.py
+++ b/astacus/node/node.py
@@ -19,6 +19,7 @@ from starlette.datastructures import URL
 from typing import Generic, TypeVar
 
 import logging
+import msgspec
 
 logger = logging.getLogger(__name__)
 SNAPSHOTTER_KEY = "node_snapshotter"
@@ -34,7 +35,7 @@ class NodeOp(op.Op, Generic[Request, Result]):
         self.start_op = n.start_op
         self.config = n.config
         self._still_locked_callback = n.state.still_locked_callback
-        self._sent_result_json: str | None = None
+        self._sent_result_json: bytes | None = None
         self.req = req
         self.result = self.create_result()
         self.result.az = self.config.az
@@ -57,7 +58,7 @@ class NodeOp(op.Op, Generic[Request, Result]):
         if not self.still_running_callback():
             logger.debug("send_result omitted - not running")
             return
-        result_json = self.result.json(exclude_defaults=True)
+        result_json = msgspec.json.encode(self.result)
         if result_json == self._sent_result_json:
             return
         self._sent_result_json = result_json

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,8 +10,9 @@ zip_safe = False
 # SKIP-IN-RPM
 install_requires =
   PyYAML==6.0
-  fastapi==0.86.0
-  httpx==0.22.0
+  fastapi==0.99.0
+  httpx==0.24.1
+  msgspec==0.18.6
   protobuf==3.19.4
   rohmu>=2.2.0,<3
   sentry-sdk==1.6.0

--- a/tests/unit/coordinator/plugins/test_m3db.py
+++ b/tests/unit/coordinator/plugins/test_m3db.py
@@ -31,6 +31,7 @@ from fastapi import BackgroundTasks
 from starlette.datastructures import URL
 from tests.unit.common.test_m3placement import create_dummy_placement
 
+import datetime
 import pytest
 import respx
 
@@ -151,15 +152,13 @@ async def test_m3_restore(coordinator: Coordinator, plugin: M3DBPlugin, etcd_cli
     context = StepsContext()
     context.set_result(
         BackupManifestStep,
-        ipc.BackupManifest.parse_obj(
-            {
-                "plugin": "m3db",
-                "plugin_data": PLUGIN_DATA,
-                "attempt": 1,
-                "snapshot_results": [],
-                "start": "2020-01-01 12:00",
-                "upload_results": [],
-            }
+        ipc.BackupManifest(
+            plugin=ipc.Plugin.m3db,
+            plugin_data=PLUGIN_DATA,
+            attempt=1,
+            snapshot_results=[],
+            start=datetime.datetime(2020, 1, 1, 12, 00, tzinfo=datetime.UTC),
+            upload_results=[],
         ),
     )
     fail_at = rt.fail_at

--- a/tests/unit/coordinator/test_backup.py
+++ b/tests/unit/coordinator/test_backup.py
@@ -30,7 +30,7 @@ def test_backup(fail_at: int | None, app: FastAPI, client: TestClient, storage: 
     nodes = app.state.coordinator_config.nodes
     with respx.mock:
         for node in nodes:
-            respx.get(f"{node.url}/metadata").respond(json=metadata().jsondict())
+            respx.get(f"{node.url}/metadata").respond(content=metadata().body)
             respx.post(f"{node.url}/unlock?locker=x&ttl=0").respond(json={"locked": False})
             # Failure point 1: Lock fails
             respx.post(f"{node.url}/lock?locker=x&ttl=600").respond(json={"locked": fail_at != 1})
@@ -170,7 +170,7 @@ def test_backup_stats(mock_time: Mock, app: FastAPI, client: TestClient) -> None
     nodes = app.state.coordinator_config.nodes
     with respx.mock:
         for node in nodes:
-            respx.get(f"{node.url}/metadata").respond(json=metadata().jsondict())
+            respx.get(f"{node.url}/metadata").respond(content=metadata().body)
             respx.post(f"{node.url}/unlock?locker=x&ttl=0").respond(json={"locked": False})
             respx.post(f"{node.url}/lock?locker=x&ttl=600").respond(json={"locked": True})
             respx.post(f"{node.url}/snapshot").respond(json={"op_id": 42, "status_url": f"{node.url}/snapshot/result"})

--- a/tests/unit/coordinator/test_list.py
+++ b/tests/unit/coordinator/test_list.py
@@ -26,7 +26,6 @@ from pytest_mock import MockerFixture
 from tests.utils import create_rohmu_config
 
 import datetime
-import json
 import pytest
 
 
@@ -43,12 +42,12 @@ def test_api_list(client: TestClient, populated_mstorage: MultiRohmuStorage, moc
                     "backups": [
                         {
                             "attempt": 1,
-                            "end": "2020-02-02T12:34:56+00:00",
+                            "end": "2020-02-02T12:34:56Z",
                             "nodes": 1,
                             "files": 1,
                             "name": "1",
                             "plugin": "files",
-                            "start": "2020-01-01T21:43:00+00:00",
+                            "start": "2020-01-01T21:43:00Z",
                             "cluster_files": 1,
                             "cluster_data_size": 6,
                             "total_size": 6,
@@ -57,12 +56,12 @@ def test_api_list(client: TestClient, populated_mstorage: MultiRohmuStorage, moc
                         },
                         {
                             "attempt": 1,
-                            "end": "2020-02-02T12:34:56+00:00",
+                            "end": "2020-02-02T12:34:56Z",
                             "nodes": 1,
                             "files": 1,
                             "name": "2",
                             "plugin": "files",
-                            "start": "2020-01-01T21:43:00+00:00",
+                            "start": "2020-01-01T21:43:00Z",
                             "cluster_files": 1,
                             "cluster_data_size": 6,
                             "total_size": 6,
@@ -76,12 +75,12 @@ def test_api_list(client: TestClient, populated_mstorage: MultiRohmuStorage, moc
                     "backups": [
                         {
                             "attempt": 1,
-                            "end": "2020-02-02T12:34:56+00:00",
+                            "end": "2020-02-02T12:34:56Z",
                             "nodes": 1,
                             "files": 1,
                             "name": "3",
                             "plugin": "files",
-                            "start": "2020-01-01T21:43:00+00:00",
+                            "start": "2020-01-01T21:43:00Z",
                             "cluster_files": 1,
                             "cluster_data_size": 6,
                             "total_size": 6,
@@ -217,9 +216,7 @@ def fixture_backup_manifest() -> BackupManifest:
 
 def test_compute_deduplicated_snapshot_file_stats(backup_manifest: BackupManifest) -> None:
     """Test backup stats are computed correctly in the presence of duplicate snapshot files."""
-    manifest_json = json.loads(backup_manifest.json())
-    snapshot_results_json = manifest_json["snapshot_results"]
-    num_files, total_size = compute_deduplicated_snapshot_file_stats(snapshot_results_json)
+    num_files, total_size = compute_deduplicated_snapshot_file_stats(backup_manifest)
     assert (num_files, total_size) == (6, 6000)
 
 

--- a/tests/unit/coordinator/test_restore.py
+++ b/tests/unit/coordinator/test_restore.py
@@ -20,7 +20,7 @@ from typing import Any
 
 import httpx
 import json
-import pydantic
+import msgspec
 import pytest
 import respx
 
@@ -196,9 +196,9 @@ def test_node_to_backup_index(
         ({"backup_index": 1, "node_url": "url2"}, [None, None, 1], does_not_raise()),
         ({"backup_hostname": "host1", "node_url": "url2"}, [None, None, 1], does_not_raise()),
         # errors - invalid node spec
-        ({}, None, pytest.raises(pydantic.ValidationError)),
-        ({"backup_index": 42, "backup_hostname": "foo", "node_index": 42}, None, pytest.raises(pydantic.ValidationError)),
-        ({"backup_index": 42, "node_index": 42, "node_url": "foo"}, None, pytest.raises(pydantic.ValidationError)),
+        ({}, None, pytest.raises(msgspec.ValidationError)),
+        ({"backup_index": 42, "backup_hostname": "foo", "node_index": 42}, None, pytest.raises(msgspec.ValidationError)),
+        ({"backup_index": 42, "node_index": 42, "node_url": "foo"}, None, pytest.raises(msgspec.ValidationError)),
         # out of range
         ({"backup_index": -1, "node_index": 2}, [None, None, 1], pytest.raises(exceptions.NotFoundException)),
         ({"backup_index": 1, "node_index": -2}, [None, None, 1], pytest.raises(exceptions.NotFoundException)),
@@ -216,7 +216,7 @@ def test_partial_node_to_backup_index(
     snapshot_results = [ipc.SnapshotResult(hostname=f"host{i}") for i in range(num_nodes)]
     nodes = [CoordinatorNode(url=f"url{i}") for i in range(num_nodes)]
     with exception:
-        partial_restore_nodes = [ipc.PartialRestoreRequestNode.parse_obj(partial_node_spec)]
+        partial_restore_nodes = [msgspec.convert(partial_node_spec, ipc.PartialRestoreRequestNode)]
         assert expected_index == get_node_to_backup_index(
             partial_restore_nodes=partial_restore_nodes, snapshot_results=snapshot_results, nodes=nodes
         )

--- a/tests/unit/node/test_node_download.py
+++ b/tests/unit/node/test_node_download.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from pytest_mock import MockerFixture
 from tests.unit.node.conftest import build_snapshot_and_snapshotter, create_files_at_path
 
+import msgspec
 import pytest
 
 
@@ -98,5 +99,5 @@ def test_api_clear(client: TestClient, mocker: MockerFixture) -> None:
 
     # Decode the (result endpoint) response using the model
     response = m.call_args[1]["data"]
-    result = ipc.NodeResult.parse_raw(response)
+    result = msgspec.json.decode(response, type=ipc.NodeResult)
     assert result.progress.finished_successfully

--- a/tests/unit/node/test_node_snapshot.py
+++ b/tests/unit/node/test_node_snapshot.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from pytest_mock import MockerFixture
 from tests.unit.node.conftest import build_snapshot_and_snapshotter, create_files_at_path
 
+import msgspec
 import os
 import pytest
 
@@ -95,7 +96,7 @@ def test_api_snapshot_and_upload(client: TestClient, mocker: MockerFixture) -> N
     response = client.post("/node/snapshot")
     assert response.status_code == 422, response.json()
 
-    req_json: JsonObject = {"root_globs": ["*"]}
+    req_json: JsonObject = {"groups": [{"root_glob": "*"}]}
     response = client.post("/node/snapshot", json=req_json)
     assert response.status_code == 409, response.json()
 
@@ -110,7 +111,7 @@ def test_api_snapshot_and_upload(client: TestClient, mocker: MockerFixture) -> N
 
     # Decode the (result endpoint) response using the model
     response = m.call_args[1]["data"]
-    result = ipc.SnapshotResult.parse_raw(response)
+    result = msgspec.json.decode(response, type=ipc.SnapshotResult)
     assert result.progress.finished_successfully
     assert result.hashes
     assert result.files
@@ -121,16 +122,16 @@ def test_api_snapshot_and_upload(client: TestClient, mocker: MockerFixture) -> N
     response = client.post("/node/upload")
     assert response.status_code == 422, response.json()
     response = client.post(
-        "/node/upload", json={"storage": "x", "hashes": [x.dict() for x in result.hashes], "result_url": url}
+        "/node/upload", json={"storage": "x", "hashes": [msgspec.to_builtins(x) for x in result.hashes], "result_url": url}
     )
     assert response.status_code == 200, response.json()
     response = m.call_args[1]["data"]
-    result2 = ipc.SnapshotUploadResult.parse_raw(response)
+    result2 = msgspec.json.decode(response, type=ipc.SnapshotUploadResult)
     assert result2.progress.finished_successfully
 
 
 def test_api_snapshot_error(client: TestClient, mocker: MockerFixture) -> None:
-    req_json = {"root_globs": ["*"]}
+    req_json: JsonObject = {"groups": []}
     response = client.post("/node/lock?locker=x&ttl=10")
     assert response.status_code == 200, response.json()
     response = client.post("/node/snapshot", json=req_json)


### PR DESCRIPTION
This isn't ideal but still greatly improves memory usage and should enable us
to deal with larger backups while working on a better solution for even larger backups.

The main goal is to replace `BackupManifest` and its components, but that still requires
migrating all the models for the API request/response (or creating duplicates
and copying between the two, which would waste all the saved memory usage).

The config was spared and kept as pydantic, to avoid dealing with rohmu models,
this required splitting the Retention model that was both used for config and ipc.

While not perfect, this still reduces the peak memory usage  from 526MiB to 217MiB
during backups and from 563MiB to 210MiB during restore (using a test procedure
with a ClickHouse backups containing many partitions).

A part of that memory is constant usage from python itself, so the savings for larger
backups are expected to be more than 60%.
