### PR TITLE
Khatskevich speedup backup restoration [DDB-855]

### DIFF
--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -1,6 +1,6 @@
 # -*- dockerfile -*-
 
-FROM fedora:35
+FROM fedora:38
 MAINTAINER "Markus Stenberg <mstenber@aiven.io>"
 
 RUN dnf install -y sudo make

--- a/astacus/common/rohmustorage.py
+++ b/astacus/common/rohmustorage.py
@@ -7,14 +7,18 @@ Rohmu-specific actual object storage implementation
 
 """
 from .storage import Json, MultiStorage, Storage, StorageUploadResult
-from .utils import AstacusModel
+from .utils import AstacusModel, fifo_cache
 from astacus.common import exceptions
 from collections.abc import Mapping
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
 from enum import Enum
 from pydantic import Field
 from rohmu import errors, rohmufile
 from rohmu.compressor import CompressionStream
 from rohmu.encryptor import EncryptorStream
+from rohmu.typing import Metadata
 from typing import BinaryIO, TypeAlias
 
 import io
@@ -110,15 +114,14 @@ class RohmuStorage(Storage):
 
     @rohmu_error_wrapper
     def _download_key_to_file(self, key, f: BinaryIO) -> bool:
-        raw_metadata: dict = self.storage.get_metadata_for_key(key)
         with tempfile.TemporaryFile(dir=self.config.temporary_directory) as temp_file:
-            self.storage.get_contents_to_fileobj(key, temp_file)
+            raw_metadata: Metadata = self.storage.get_contents_to_fileobj(key, temp_file)
             temp_file.seek(0)
             rohmufile.read_file(
                 input_obj=temp_file,
                 output_obj=f,
                 metadata=raw_metadata,
-                key_lookup=self._private_key_lookup,
+                key_lookup=self._loaded_private_key_lookup,
                 log_func=logger.debug,
             )
         return True
@@ -126,11 +129,22 @@ class RohmuStorage(Storage):
     def _list_key(self, key: str) -> list[str]:
         return [os.path.basename(o["name"]) for o in self.storage.list_iter(key, with_metadata=False)]
 
-    def _private_key_lookup(self, key_id: str) -> str:
-        return self.config.encryption_keys[key_id].private
+    @fifo_cache(size=1)
+    def _loaded_private_key_lookup(self, key_id: str) -> RSAPrivateKey:
+        private_key_pem = self.config.encryption_keys[key_id].private.encode("ascii")
+        # RSA key validation is compute-intense and require caching
+        private_key = serialization.load_pem_private_key(data=private_key_pem, password=None, backend=default_backend())
+        if not isinstance(private_key, RSAPrivateKey):
+            raise ValueError("Key must be RSA")
+        return private_key
 
-    def _public_key_lookup(self, key_id: str) -> str:
-        return self.config.encryption_keys[key_id].public
+    @fifo_cache(size=1)
+    def _loaded_public_key_lookup(self, key_id: str) -> RSAPublicKey:
+        public_key_pem = self.config.encryption_keys[key_id].public.encode("ascii")
+        public_key = serialization.load_pem_public_key(public_key_pem, backend=default_backend())
+        if not isinstance(public_key, RSAPublicKey):
+            raise ValueError("Key must be RSA")
+        return public_key
 
     @rohmu_error_wrapper
     def _upload_key_from_file(self, key: str, f: BinaryIO, file_size: int) -> StorageUploadResult:
@@ -143,7 +157,7 @@ class RohmuStorage(Storage):
             wrapped_file = CompressionStream(wrapped_file, compression.algorithm, compression.level)
         if encryption_key_id:
             metadata.encryption_key_id = encryption_key_id
-            rsa_public_key = self._public_key_lookup(encryption_key_id)
+            rsa_public_key = self._loaded_public_key_lookup(encryption_key_id)
             wrapped_file = EncryptorStream(wrapped_file, rsa_public_key)
         rohmu_metadata = metadata.dict(exclude_defaults=True, by_alias=True)
         self.storage.store_file_object(key, wrapped_file, metadata=rohmu_metadata)

--- a/astacus/common/utils.py
+++ b/astacus/common/utils.py
@@ -11,12 +11,12 @@ Shared utilities (between coordinator and node)
 from __future__ import annotations
 
 from abc import ABC
-from collections.abc import AsyncIterable, Callable, Iterable, Mapping
+from collections import deque
 from contextlib import contextmanager
 from multiprocessing.dummy import Pool  # fastapi + fork = bad idea
 from pathlib import Path
 from pydantic import BaseModel
-from typing import Any, Final, TypeVar
+from typing import Any, AsyncIterable, Callable, Final, Generic, Hashable, Iterable, Mapping, TypeAlias, TypeVar
 
 import asyncio
 import datetime
@@ -338,3 +338,68 @@ def parse_umask(proc_status: str) -> int:
     if umask_line := re.search(r"^Umask:\s+(0\d\d\d)$", proc_status, flags=re.MULTILINE):
         return int(umask_line.group(1), 8)
     return FALLBACK_UMASK
+
+
+FifoValue = TypeVar("FifoValue")
+
+
+class FifoCache(Generic[FifoValue]):
+    def __init__(self, size: int = 1) -> None:
+        if size < 1:
+            raise ValueError("FifoCache size must be at least 1")
+        self.size: int = size
+        self.cache: dict[Hashable, FifoValue] = {}
+        self.key_queue: deque[Hashable] = deque()
+
+    def __contains__(self, key: Hashable) -> bool:
+        return key in self.cache
+
+    def __getitem__(self, key: Hashable) -> FifoValue | None:
+        return self.cache.get(key)
+
+    def __setitem__(self, key: Hashable, value: FifoValue) -> None:
+        if key in self.cache:
+            self.cache[key] = value
+        if len(self.cache) >= self.size:
+            self.cache.pop(self.key_queue.popleft())
+        self.key_queue.append(key)
+        self.cache[key] = value
+
+    def __len__(self) -> int:
+        return len(self.cache)
+
+
+CacheMethodClassT = TypeVar("CacheMethodClassT", bound=object)
+CacheFuncArg = TypeVar("CacheFuncArg", bound=Hashable)
+CacheValue = TypeVar("CacheValue")
+CachedMethod: TypeAlias = Callable[[CacheMethodClassT, CacheFuncArg], CacheValue]
+
+
+def fifo_cache(size: int) -> Callable[[CachedMethod], CachedMethod]:
+    """Decorator for caching method results in a FIFO cache of given size.
+
+    The decorated method must take only one hashable argument.
+    The cache is per-instance.
+    Not thread-safe.
+    """
+
+    def decorator(method: CachedMethod) -> Callable:
+        cache_attribute_name = "__fifo_cache_" + method.__name__
+
+        # Type alias cannot be used here, as mypy cannot deduct from inner types
+        def wrapper(self: Callable[[CacheMethodClassT, CacheFuncArg], CacheValue], key: CacheFuncArg) -> CacheValue:
+            cache: FifoCache[CacheValue] | None = getattr(self, cache_attribute_name, None)
+            if cache is None:
+                cache = FifoCache[CacheValue](size)
+                setattr(self, cache_attribute_name, cache)
+            if key in cache:
+                val = cache[key]
+                assert val is not None
+                return val
+            value = method(self, key)
+            cache[key] = value
+            return value
+
+        return wrapper
+
+    return decorator

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ install_requires =
   fastapi==0.86.0
   httpx==0.22.0
   protobuf==3.19.4
-  rohmu>=2.1.0,<2.2
+  rohmu>=2.2.0,<3
   sentry-sdk==1.6.0
   tabulate==0.9.0
   typing-extensions==4.7.1


### PR DESCRIPTION
rohmu: speedup file decryption
    
Improve backup restoration speed by removing unnecessary operations.
Remove unnecessary operations for each file download:
1. second retrival of key metadata
2. RSA private key loading, which requires compute-intensive checks
    
For workload with many small files it results to a large speedup.
    
[DDB-885]