### PR TITLE
clickhouse: make restore work with annoy index

### DIFF
--- a/astacus/coordinator/plugins/clickhouse/steps.py
+++ b/astacus/coordinator/plugins/clickhouse/steps.py
@@ -509,6 +509,7 @@ class RestoreReplicatedDatabasesStep(Step[None]):
             # we need to re-enable these custom global settings when creating the table again.
             # We can enable these settings unconditionally because they are harmless
             # for tables not needing them.
+            b"SET allow_experimental_annoy_index=true",
             b"SET allow_experimental_geo_types=true",
             b"SET allow_experimental_object_type=true",
             b"SET allow_suspicious_codecs=true",

--- a/tests/unit/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_steps.py
@@ -785,6 +785,7 @@ async def test_creates_all_replicated_databases_and_tables_in_manifest() -> None
         b"SET receive_timeout=10.0",
         b"CREATE DATABASE `db-two` UUID '00000000-0000-0000-0000-000000000012'"
         b" ENGINE = Replicated('/clickhouse/databases/db%2Dtwo', '{my_shard}', '{my_replica}')",
+        b"SET allow_experimental_annoy_index=true",
         b"SET allow_experimental_geo_types=true",
         b"SET allow_experimental_object_type=true",
         b"SET allow_suspicious_codecs=true",
@@ -843,6 +844,7 @@ async def test_creates_all_replicated_databases_and_tables_in_manifest_with_cust
         b"CREATE DATABASE `db-two` UUID '00000000-0000-0000-0000-000000000012'"
         b" ENGINE = Replicated('/clickhouse/databases/db%2Dtwo', '{my_shard}', '{my_replica}') "
         b"SETTINGS cluster_username='alice', cluster_password='alice_secret'",
+        b"SET allow_experimental_annoy_index=true",
         b"SET allow_experimental_geo_types=true",
         b"SET allow_experimental_object_type=true",
         b"SET allow_suspicious_codecs=true",
@@ -886,6 +888,7 @@ async def test_drops_each_database_on_all_servers_before_recreating_it() -> None
         b" ENGINE = Replicated('/clickhouse/databases/db%2Dtwo', '{my_shard}', '{my_replica}')",
     ]
     queries_expected_on_a_single_node = [
+        b"SET allow_experimental_annoy_index=true",
         b"SET allow_experimental_geo_types=true",
         b"SET allow_experimental_object_type=true",
         b"SET allow_suspicious_codecs=true",


### PR DESCRIPTION
Like other experimental settings, whether they should be allowed or not is decided somewhere else, but astacus should not unnecessary fail if they were allowed.

[DDB-500]