### PR TITLE
Properly support materialized views restoration

### DIFF
--- a/astacus/coordinator/plugins/clickhouse/engines.py
+++ b/astacus/coordinator/plugins/clickhouse/engines.py
@@ -1,0 +1,13 @@
+"""
+Copyright (c) 2024 Aiven Ltd
+See LICENSE for details
+"""
+
+import enum
+
+
+# This enum contains only used constants
+class TableEngine(enum.Enum):
+    MySQL = "MySQL"
+    PostgreSQL = "PostgreSQL"
+    S3 = "S3"

--- a/tests/integration/coordinator/plugins/clickhouse/conftest.py
+++ b/tests/integration/coordinator/plugins/clickhouse/conftest.py
@@ -204,6 +204,12 @@ async def fixture_minio_bucket(minio: MinioService) -> AsyncIterator[MinioBucket
         yield bucket
 
 
+@pytest.fixture(scope="function", name="function_minio_bucket")
+async def fixture_function_minio_bucket(minio: MinioService) -> AsyncIterator[MinioBucket]:
+    with minio.bucket(bucket_name="function-clickhouse-bucket") as bucket:
+        yield bucket
+
+
 @contextlib.asynccontextmanager
 async def create_minio_service(ports: Ports) -> AsyncIterator[MinioService]:
     server_port = ports.allocate()

--- a/tests/integration/coordinator/plugins/clickhouse/conftest.py
+++ b/tests/integration/coordinator/plugins/clickhouse/conftest.py
@@ -337,6 +337,10 @@ def create_clickhouse_configs(
     minio_bucket: MinioBucket | None = None,
     object_storage_prefix: str = "/",
 ):
+    # Helper for emitting XML configuration: avoid very long lines and deduplicate
+    def setting(name: str, value: int | float | str):
+        return f"<{name}>{value}</{name}>"
+
     replicas = "\n".join(
         f"""
         <replica>
@@ -409,9 +413,29 @@ def create_clickhouse_configs(
                             <port>{zookeeper.port}</port>
                         </node>
                     </zookeeper>
-                    <mark_cache_size>5368709120</mark_cache_size>
-                    <max_server_memory_usage_to_ram_ratio>0.5</max_server_memory_usage_to_ram_ratio>
-                    <enable_system_unfreeze>true</enable_system_unfreeze>
+                    <merge_tree>
+                        {setting("number_of_free_entries_in_pool_to_execute_mutation", 2)}
+                        {setting("number_of_free_entries_in_pool_to_execute_optimize_entire_partition", 2)}
+                    </merge_tree>
+                    {setting("background_pool_size", 4)}
+                    {setting("background_move_pool_size", 2)}
+                    {setting("background_fetches_pool_size", 2)}
+                    {setting("background_common_pool_size", 4)}
+                    {setting("background_buffer_flush_schedule_pool_size", 2)}
+                    {setting("background_schedule_pool_size", 2)}
+                    {setting("background_message_broker_schedule_pool_size", 2)}
+                    {setting("background_distributed_schedule_pool_size", 2)}
+                    {setting("tables_loader_foreground_pool_size", 2)}
+                    {setting("tables_loader_background_pool_size", 2)}
+                    {setting("restore_threads", 2)}
+                    {setting("backup_threads", 2)}
+                    {setting("backups_io_thread_pool_queue_size", 2)}
+                    {setting("max_parts_cleaning_thread_pool_size", 2)}
+                    {setting("max_active_parts_loading_thread_pool_size", 2)}
+                    {setting("max_outdated_parts_loading_thread_pool_size", 2)}
+                    {setting("mark_cache_size", 5368709120)}
+                    {setting("max_server_memory_usage_to_ram_ratio", 0.5)}
+                    {setting("enable_system_unfreeze", "true")}
                     <user_directories>
                         <users_xml>
                             <path>{str(data_dir / "users.xml")}</path>

--- a/tests/unit/coordinator/plugins/clickhouse/test_dependencies.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_dependencies.py
@@ -48,6 +48,7 @@ def test_tables_sorted_by_dependencies() -> None:
         dependencies=[(b"db_one", b"t2"), (b"db_one", b"t3")],
     )
     assert tables_sorted_by_dependencies([t1, t2, t3, t4]) == [t1, t4, t3, t2]
+    assert tables_sorted_by_dependencies([t2, t3, t4, t1]) == [t1, t4, t3, t2]
 
 
 def test_dangling_table_dependency_doesnt_crash() -> None:
@@ -94,6 +95,7 @@ def test_access_entities_sorted_by_dependencies() -> None:
         type="R", uuid=uuid.UUID("00000000-0000-abcd-0000-000000000004"), name=b"a4", attach_query=b"ATTACH ROLE a4"
     )
     assert access_entities_sorted_by_dependencies([a1, a2, a3, a4]) == [a4, a2, a3, a1]
+    assert access_entities_sorted_by_dependencies([a2, a4, a3, a1]) == [a4, a2, a3, a1]
 
 
 def test_dangling_access_entities_doesnt_crash() -> None:


### PR DESCRIPTION
This pr enables the restoration of databases with materialized views when:
1. Source table was deleted before backup.
2. Source table was not backed up by Astacus.

This is achieved by using `ATTACH` instead of `CREATE`, which performs
fewer checks at the moment of creation.

Misc: add a test for basic views to make sure they are restored properly
in similar case.

[DDB-890]