### PR TITLE
Pin mypy to version 1.8.0

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -69,6 +69,10 @@ ignore_missing_imports = True
 [mypy-systemd.*]
 ignore_missing_imports = True
 
+# uvicorn has types starting version 0.19, but we are using 0.15
+[mypy-uvicorn.*]
+ignore_missing_imports = True
+
 # TBD: When someone has time, implement these for whole codebase
 
 [mypy-astacus.common.cassandra.*]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     # makefile convenience"
-    "pre-commit>=2.20.0",
+    "pre-commit>=3.7.0",
     # pre-commit tasks in Makefile need these"
     "anyio==3.5.0",
     "pylint==2.15.5",
@@ -53,10 +53,12 @@ dev = [
     "pytest-watch==4.2.0",
     "pytest==7.2.2",
     # pinning mypy to the same version as pre-commit"
-    "mypy==1.0.0",
+    "mypy==1.8.0",
     # types for things that don't seem to have them"
     "types-PyYAML>=6.0.12.2",
+    "types-requests>=2.28.11.5",
     "types-tabulate>=0.9.0.0",
+    "types-ujson>=5.9.0.0",
     "types-urllib3>=1.26.25.4",
     "typing_extensions>=4.4.0",
     "freezegun>=1.2",


### PR DESCRIPTION
Ignore uvicorn typing errors for the time being, and improve pyproject.toml dependencies when running mypy outside the pre-commit venv.