### PR TITLE
ci: use local mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,19 +40,11 @@ repos:
         exclude: ^vendor/
         args:
           - --rcfile=.pylintrc
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
-    hooks:
       - id: mypy
+        name: mypy
+        entry: mypy
+        language: python
+        pass_filenames: true
+        require_serial: true
+        types: [ python ]
         exclude: ^setup.py|^vendor/|^astacus/proto/
-        additional_dependencies:
-          - types-PyYAML>=6.0.12.2
-          - types-requests>=2.28.11.5
-          - types-tabulate>=0.9.0.0
-          - types-ujson>=5.9.0.0
-          - types-urllib3>=1.26.25.4
-          - typing_extensions>=3.10.0
-          - msgspec==0.18.6
-          - pydantic==1.10.9
-          - starlette==0.27.0


### PR DESCRIPTION
This removes duplicate dependency definitions and detects more errors.