### PR TITLE
tests: fix assertion

### DIFF
--- a/tests/unit/common/cassandra/test_client.py
+++ b/tests/unit/common/cassandra/test_client.py
@@ -19,7 +19,7 @@ def test_cassandra_session(mocker: MockFixture) -> None:
     assert session.cluster_metadata == 42
 
     session.cluster_refresh_schema_metadata(max_schema_agreement_wait=7.0)
-    assert ccluster.refresh_schema_metadata.called_with(max_schema_agreement_wait=7.0)
+    ccluster.refresh_schema_metadata.assert_called_with(max_schema_agreement_wait=7.0)
 
     test_multi_statement = """
 first


### PR DESCRIPTION
Fixes: 

```
AttributeError: 'called_with' is not a valid assertion. Use a spec for the mock if 'called_with' is meant to be an attribute.
``` 

on python 3.12.