### PR TITLE
Transition to using a local hook for type checking and fix surfaced type errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,18 +41,10 @@ repos:
         args:
           - --rcfile=.pylintrc
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.8.0
+  - repo: local
     hooks:
       - id: mypy
-        exclude: ^setup.py|^vendor/|^astacus/proto/
-        additional_dependencies:
-          - types-PyYAML>=6.0.12.2
-          - types-requests>=2.28.11.5
-          - types-tabulate>=0.9.0.0
-          - types-ujson>=5.9.0.0
-          - types-urllib3>=1.26.25.4
-          - typing_extensions>=3.10.0
-          - msgspec==0.18.6
-          - pydantic==1.10.9
-          - starlette==0.27.0
+        name: mypy
+        entry: mypy
+        language: system
+        types: [python]

--- a/Makefile
+++ b/Makefile
@@ -11,19 +11,16 @@ GENERATED_PROTOBUFS = $(patsubst %.proto,%_pb2.py,$(PROTOBUFS))
 
 GENERATED = $(GENERATED_PROTOBUFS)
 
-PYTHON = python3
-DNF_INSTALL = sudo dnf install -y
-
 ZOOKEEPER_VERSION = 3.8.4
 ZOOKEEPER_HASH = 284cb4675adb64794c63d95bf202d265cebddc0cda86ac86fb0ede8049de9187
 
 default: $(GENERATED)
 
 venv: default
-	$(PYTHON) -m venv venv && source venv/bin/activate && pip install -U pip && pip install . ".[dev]"
+	python3 -m venv venv && source venv/bin/activate && pip install -U pip && pip install . ".[dev]"
 
 clean:
-	rm -rf rpm/ $(GENERATED)
+	rm -rf rpm/ $(GENERATED) venv/ .mypy_cache/ astacus.egg-info/
 
 
 .PHONY: build-dep-fedora

--- a/astacus/common/progress.py
+++ b/astacus/common/progress.py
@@ -4,8 +4,8 @@ Copyright (c) 2020 Aiven Ltd
 See LICENSE for details
 
 """
-from pyparsing import Iterable
-from typing_extensions import Self, TypeVar
+from collections.abc import Iterable, Iterator, Sequence
+from typing import Self, TypeVar
 
 import logging
 import math
@@ -52,7 +52,7 @@ class Progress(msgspec.Struct, kw_only=True):
         finished = ", finished" if self.final else ""
         return f"{self.handled}/{self.total} handled, {self.failed} failures{finished}"
 
-    def wrap(self, i: Iterable[T]) -> Iterable[T]:
+    def wrap(self, i: Sequence[T]) -> Iterator[T]:
         """Iterate over i, updating progress as we go."""
         try:
             self.add_total(len(i))

--- a/astacus/common/rohmustorage.py
+++ b/astacus/common/rohmustorage.py
@@ -18,8 +18,9 @@ from pydantic import Field
 from rohmu import errors, rohmufile
 from rohmu.compressor import CompressionStream
 from rohmu.encryptor import EncryptorStream
-from rohmu.typing import Metadata
-from typing import BinaryIO, TypeAlias
+from rohmu.filewrap import Stream
+from rohmu.typing import FileLike, Metadata
+from typing import BinaryIO, IO, TypeAlias
 
 import contextlib
 import io
@@ -114,7 +115,7 @@ class RohmuStorage(Storage):
             raise exceptions.CompressionOrEncryptionRequired()
 
     @rohmu_error_wrapper
-    def _download_key_to_file(self, key, f: BinaryIO) -> bool:
+    def _download_key_to_file(self, key, f: FileLike) -> bool:
         with tempfile.TemporaryFile(dir=self.config.temporary_directory) as temp_file:
             raw_metadata: Metadata = self.storage.get_contents_to_fileobj(key, temp_file)
             temp_file.seek(0)
@@ -148,20 +149,22 @@ class RohmuStorage(Storage):
         return public_key
 
     @rohmu_error_wrapper
-    def _upload_key_from_file(self, key: str, f: BinaryIO, file_size: int) -> StorageUploadResult:
+    def _upload_key_from_file(self, key: str, f: IO[bytes], file_size: int) -> StorageUploadResult:
         encryption_key_id = self.config.encryption_key_id
         compression = self.config.compression
         metadata = RohmuMetadata()
-        wrapped_file = f
+        wrapped_file: IO[bytes] | Stream = f
         if compression.algorithm:
             metadata.compression_algorithm = compression.algorithm
-            wrapped_file = CompressionStream(wrapped_file, compression.algorithm, compression.level)
+            wrapped_file = CompressionStream(wrapped_file, compression.algorithm.value, compression.level)
         if encryption_key_id:
             metadata.encryption_key_id = encryption_key_id
             rsa_public_key = self._loaded_public_key_lookup(encryption_key_id)
             wrapped_file = EncryptorStream(wrapped_file, rsa_public_key)
         rohmu_metadata = metadata.dict(exclude_defaults=True, by_alias=True)
-        self.storage.store_file_object(key, wrapped_file, metadata=rohmu_metadata)
+        # BaseTransfer.store_file_object is compatible with file descriptors of type IO[bytes] and Stream
+        # However, the BinaryIO parameter type is too strict for the union type we want to pass here.
+        self.storage.store_file_object(key, wrapped_file, metadata=rohmu_metadata)  # type: ignore[arg-type]
         return StorageUploadResult(size=file_size, stored_size=wrapped_file.tell())
 
     storage_name: str = ""
@@ -186,7 +189,7 @@ class RohmuStorage(Storage):
     def list_hexdigests(self) -> list[str]:
         return self._list_key(self.hexdigest_key)
 
-    def download_hexdigest_to_file(self, hexdigest: str, f: BinaryIO) -> bool:
+    def download_hexdigest_to_file(self, hexdigest: str, f: FileLike) -> bool:
         key = os.path.join(self.hexdigest_key, hexdigest)
         return self._download_key_to_file(key, f)
 

--- a/astacus/common/snapshot.py
+++ b/astacus/common/snapshot.py
@@ -4,7 +4,7 @@ See LICENSE for details
 """
 from astacus.common.magic import DEFAULT_EMBEDDED_FILE_SIZE
 from collections.abc import Sequence
-from typing_extensions import Self
+from typing import Self
 
 import dataclasses
 

--- a/astacus/common/storage.py
+++ b/astacus/common/storage.py
@@ -8,6 +8,7 @@ from .exceptions import NotFoundException
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from pathlib import Path
+from rohmu.typing import FileLike
 from typing import BinaryIO, Callable, ContextManager, Generic, ParamSpec, TypeAlias, TypeVar
 
 import contextlib
@@ -46,7 +47,7 @@ class HexDigestStorage(ABC):
         return b.read()
 
     @abstractmethod
-    def download_hexdigest_to_file(self, hexdigest: str, f: BinaryIO) -> bool:
+    def download_hexdigest_to_file(self, hexdigest: str, f: FileLike) -> bool:
         ...
 
     def download_hexdigest_to_path(self, hexdigest: str, filename: str | Path) -> None:
@@ -147,7 +148,7 @@ class FileStorage(Storage):
         return self._list(self.hexdigest_suffix)
 
     @file_error_wrapper
-    def download_hexdigest_to_file(self, hexdigest: str, f: BinaryIO) -> bool:
+    def download_hexdigest_to_file(self, hexdigest: str, f: FileLike) -> bool:
         logger.info("download_hexdigest_to_file %r", hexdigest)
         path = self._hexdigest_to_path(hexdigest)
         f.write(path.read_bytes())

--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -839,12 +839,12 @@ async def upload_node_index_datas(
 async def get_nodes_metadata(
     cluster: Cluster, *, nodes: Sequence[CoordinatorNode] | None = None
 ) -> list[ipc.MetadataResult]:
-    metadata_responses: Sequence[httpx.Response | None] = await cluster.request_from_nodes(
+    metadata_responses = await cluster.request_from_nodes(
         "metadata", caller="get_nodes_metadata", method="get", nodes=nodes, json=False
     )
     return [
         ipc.MetadataResult(version="", features=[])
-        if response is None
+        if not isinstance(response, httpx.Response)
         else msgspec.json.decode(response.content, type=ipc.MetadataResult)
         for response in metadata_responses
     ]

--- a/astacus/coordinator/plugins/clickhouse/config.py
+++ b/astacus/coordinator/plugins/clickhouse/config.py
@@ -7,7 +7,7 @@ from astacus.common.rohmustorage import RohmuStorageConfig
 from astacus.common.utils import AstacusModel, build_netloc
 from astacus.coordinator.plugins.zookeeper import KazooZooKeeperClient, ZooKeeperClient
 from astacus.coordinator.plugins.zookeeper_config import ZooKeeperConfiguration
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 import enum
@@ -41,7 +41,7 @@ class DiskType(enum.Enum):
 
 class DiskObjectStorageConfiguration(AstacusModel):
     default_storage: str
-    storages: dict[str, RohmuStorageConfig]
+    storages: Mapping[str, RohmuStorageConfig]
 
 
 class DiskConfiguration(AstacusModel):

--- a/astacus/coordinator/plugins/zookeeper.py
+++ b/astacus/coordinator/plugins/zookeeper.py
@@ -4,7 +4,7 @@ See LICENSE for details
 """
 from astacus.common.exceptions import TransientException
 from asyncio import to_thread
-from collections.abc import AsyncIterator, Callable, Collection, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from kazoo.client import EventType, KazooClient, KeeperState, TransactionRequest, WatchedEvent
 from kazoo.retry import KazooRetry
 
@@ -164,7 +164,7 @@ class NotEmptyError(TransientException):
 
 
 class TransactionError(TransientException):
-    def __init__(self, results: Collection[bool | TransientException]) -> None:
+    def __init__(self, results: Sequence[bool | TransientException]) -> None:
         super().__init__(results)
         self.message = f"Transaction failed: {results!r}"
         self.results = results
@@ -213,7 +213,7 @@ class KazooZooKeeperTransaction(ZooKeeperTransaction):
                 kazoo.exceptions.NoNodeError: NoNodeError,
                 kazoo.exceptions.NodeExistsError: NodeExistsError,
             }
-            mapped_results: Collection[bool | TransientException] = [
+            mapped_results: Sequence[bool | TransientException] = [
                 exceptions_map[result.__class__](operation.path) if isinstance(result, Exception) else True
                 for result, operation in zip(results, self.request.operations)
             ]

--- a/astacus/node/download.py
+++ b/astacus/node/download.py
@@ -9,6 +9,7 @@ The basic file restoration steps should be implementable by using the
 API of this module with proper parameters.
 
 """
+
 from .node import NodeOp
 from .snapshotter import Snapshotter
 from astacus.common import ipc, utils

--- a/astacus/node/snapshot_groups.py
+++ b/astacus/node/snapshot_groups.py
@@ -9,7 +9,7 @@ Classes for working with snapshot groups.
 from astacus.common.snapshot import SnapshotGroup
 from collections.abc import Iterable, Sequence
 from pathlib import Path
-from typing_extensions import Self
+from typing import Self
 from wcmatch.glob import GLOBSTAR, iglob, translate
 
 import dataclasses

--- a/astacus/node/sqlite_snapshot.py
+++ b/astacus/node/sqlite_snapshot.py
@@ -13,11 +13,18 @@ from contextlib import closing
 from functools import cached_property
 from pathlib import Path
 from typing import Iterable
-from typing_extensions import override
 
 import logging
 import os
 import sqlite3
+
+import sys
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
 
 logger = logging.getLogger(__name__)
 

--- a/astacus/node/sqlite_snapshot.py
+++ b/astacus/node/sqlite_snapshot.py
@@ -17,7 +17,6 @@ from typing import Iterable
 import logging
 import os
 import sqlite3
-
 import sys
 
 if sys.version_info >= (3, 12):

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,12 @@
 [mypy]
 python_version = 3.11
 plugins = pydantic.mypy
+exclude = (?x)(
+    ^setup.py
+    | ^vendor/
+    | ^venv/
+    | ^astacus/proto/
+  )
 
 show_error_codes = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,7 @@ dev = [
     "pytest-timeout==1.4.2",
     "pytest-watch==4.2.0",
     "pytest==7.2.2",
-    # pinning mypy to the same version as pre-commit"
-    "mypy==1.8.0",
+    "mypy==1.9.0",
     # types for things that don't seem to have them"
     "types-PyYAML>=6.0.12.2",
     "types-requests>=2.28.11.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "msgspec",
     "kazoo",
     "protobuf < 3.21",
-    "pydantic",
+    "pydantic < 2",
     "pyyaml",
     "rohmu >= 2.2.0",
     "sentry-sdk",
@@ -40,9 +40,8 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    # makefile convenience"
+    # Needed by pre-commit to lint and test the project
     "pre-commit>=3.7.0",
-    # pre-commit tasks in Makefile need these"
     "anyio==3.5.0",
     "pylint==2.17.4",
     "pytest-asyncio==0.21.1",
@@ -53,7 +52,7 @@ dev = [
     "pytest-watch==4.2.0",
     "pytest==7.2.2",
     "mypy==1.9.0",
-    # types for things that don't seem to have them"
+    # Types for things that don't seem to have them
     "types-botocore>=1.0.2",
     "types-PyYAML>=6.0.12.2",
     "types-requests>=2.28.11.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "rohmu >= 2.2.0",
     "sentry-sdk",
     "tabulate",
-    "typing-extensions >= 4.7.1",
+    "typing-extensions >= 4.7.1; python_version < '3.12'",
     "uvicorn==0.15.0",
     "wcmatch",
 ]
@@ -54,12 +54,12 @@ dev = [
     "pytest==7.2.2",
     "mypy==1.9.0",
     # types for things that don't seem to have them"
+    "types-botocore>=1.0.2",
     "types-PyYAML>=6.0.12.2",
     "types-requests>=2.28.11.5",
     "types-tabulate>=0.9.0.0",
     "types-ujson>=5.9.0.0",
     "types-urllib3>=1.26.25.4",
-    "typing_extensions>=4.7.1",
     # F38
     "coverage==7.0.5",
     "freezegun>=1.2",

--- a/tests/integration/coordinator/plugins/clickhouse/conftest.py
+++ b/tests/integration/coordinator/plugins/clickhouse/conftest.py
@@ -174,7 +174,7 @@ class MinioService:
     @contextlib.contextmanager
     def bucket(self, *, bucket_name: str) -> Iterator[MinioBucket]:
         with self.get_client(access_key=self.root_user, secret_key=self.root_password) as s3_client:
-            s3_client.create_bucket(Bucket=bucket_name, ACL="private")
+            s3_client.create_bucket(Bucket=bucket_name, ACL="private")  # type: ignore[attr-defined]
             yield MinioBucket(
                 host=self.host,
                 port=self.server_port,
@@ -183,13 +183,13 @@ class MinioService:
                 access_key_id=self.root_user,
                 secret_access_key=self.root_password,
             )
-            response = s3_client.list_objects_v2(Bucket=bucket_name)
+            response = s3_client.list_objects_v2(Bucket=bucket_name)  # type: ignore[attr-defined]
             if response["KeyCount"] > 0:
-                s3_client.delete_objects(
+                s3_client.delete_objects(  # type: ignore[attr-defined]
                     Bucket=bucket_name,
                     Delete={"Objects": [{"Key": content["Key"]} for content in response["Contents"]]},
                 )
-            s3_client.delete_bucket(Bucket=bucket_name)
+            s3_client.delete_bucket(Bucket=bucket_name)  # type: ignore[attr-defined]
 
 
 @pytest.fixture(scope="module", name="minio")
@@ -525,7 +525,7 @@ def create_astacus_configs(
             storage_type=rohmu.StorageDriver.s3,
             region="fake",
             host=minio_bucket.host,
-            port=minio_bucket.port,
+            port=str(minio_bucket.port),
             aws_access_key_id=minio_bucket.access_key_id,
             aws_secret_access_key=minio_bucket.secret_access_key,
             bucket_name=minio_bucket.name,
@@ -547,7 +547,7 @@ def create_astacus_configs(
             storage_type=rohmu.StorageDriver.s3,
             region="fake",
             host=minio_bucket.host,
-            port=minio_bucket.port,
+            port=str(minio_bucket.port),
             aws_access_key_id=minio_bucket.access_key_id,
             aws_secret_access_key=minio_bucket.secret_access_key,
             bucket_name=minio_bucket.name,

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -77,7 +77,7 @@ async def background_process(program: str | Path, *args: str | Path, **kwargs) -
 
 
 def create_astacus_config_dict(
-    *, tmpdir: Path, root_path: Path, link_path: Path, node: TestNode, plugin_config: Mapping[str, Any]
+    *, tmp_path: Path, root_path: Path, link_path: Path, node: TestNode, plugin_config: Mapping[str, Any]
 ) -> Mapping[str, Any]:
     nodes = [{"url": f"{node.url}/node"} for node in ASTACUS_NODES]
     return {
@@ -87,7 +87,7 @@ def create_astacus_config_dict(
             "root_link": str(link_path),
             "db_path": str(node.db_path),
         },
-        "object_storage": create_rohmu_config(tmpdir).jsondict(),
+        "object_storage": create_rohmu_config(tmp_path).jsondict(),
         "uvicorn": {
             "port": node.port,
             "log_level": "debug",
@@ -112,7 +112,7 @@ def create_astacus_config(
     db_path.mkdir(exist_ok=True)
     node.db_path = db_path
     a_conf = create_astacus_config_dict(
-        tmpdir=tmp_path, root_path=root_path, link_path=link_path, node=node, plugin_config=plugin_config
+        tmp_path=tmp_path, root_path=root_path, link_path=link_path, node=node, plugin_config=plugin_config
     )
     a_conf_path = a / "astacus.conf"
     a_conf_path.write_text(json.dumps(a_conf))

--- a/tests/unit/common/test_storage.py
+++ b/tests/unit/common/test_storage.py
@@ -146,6 +146,8 @@ def test_proxy_storage(mock_google_client: Mock, mock_get_credentials: Mock) -> 
         ),
         storage="x-proxy",
     )
+    assert isinstance(rs.storage, google.GoogleTransfer)
+    assert hasattr(rs.storage, "proxy_info")
     assert rs.storage.proxy_info["user"] == "REDACTED"
     assert rs.storage.proxy_info["pass"] == "REDACTED"
     assert rs.storage.proxy_info["type"] == "socks5"

--- a/tests/unit/common/test_storage.py
+++ b/tests/unit/common/test_storage.py
@@ -27,17 +27,17 @@ TEST_JSON = "jsonblob"
 TEST_JSON_DATA: Json = {"foo": 7, "array": [1, 2, 3], "true": True}
 
 
-def create_storage(*, tmpdir: Path, engine: str, **kw):
+def create_storage(*, tmp_path: Path, engine: str, **kw):
     if engine == "rohmu":
-        config = create_rohmu_config(tmpdir, **kw)
+        config = create_rohmu_config(tmp_path, **kw)
         return RohmuStorage(config=config)
     if engine == "file":
-        path = tmpdir / "test-storage-file"
+        path = tmp_path / "test-storage-file"
         return FileStorage(path)
     if engine == "cache":
         # FileStorage cache, and then rohmu filestorage underneath
-        cache_storage = FileStorage(tmpdir / "test-storage-file")
-        config = create_rohmu_config(tmpdir, **kw)
+        cache_storage = FileStorage(tmp_path / "test-storage-file")
+        config = create_rohmu_config(tmp_path, **kw)
         backend_storage = RohmuStorage(config=config)
         return CachingJsonStorage(backend_storage=backend_storage, cache_storage=cache_storage)
     raise NotImplementedError(f"unknown storage {engine}")
@@ -86,7 +86,7 @@ def test_storage(tmp_path: Path, engine: str, kw: dict[str, bool], ex: AbstractC
     if ex is None:
         ex = does_not_raise()
     with ex:
-        storage = create_storage(tmpdir=tmp_path, engine=engine, **kw)
+        storage = create_storage(tmp_path=tmp_path, engine=engine, **kw)
         if isinstance(storage, FileStorage):
             _test_hexdigeststorage(storage)
         if isinstance(storage, JsonStorage):
@@ -94,10 +94,10 @@ def test_storage(tmp_path: Path, engine: str, kw: dict[str, bool], ex: AbstractC
 
 
 def test_caching_storage(tmp_path: Path, mocker: MockerFixture) -> None:
-    storage = create_storage(tmpdir=tmp_path, engine="cache")
+    storage = create_storage(tmp_path=tmp_path, engine="cache")
     storage.upload_json(TEST_JSON, TEST_JSON_DATA)
 
-    storage = create_storage(tmpdir=tmp_path, engine="cache")
+    storage = create_storage(tmp_path=tmp_path, engine="cache")
     assert storage.list_jsons() == [TEST_JSON]
 
     # We shouldn't wind up in download method of rohmu at all.

--- a/tests/unit/common/test_storage.py
+++ b/tests/unit/common/test_storage.py
@@ -7,7 +7,6 @@ Test that RohmuStorage works as advertised.
 TBD: Test with something else than local files?
 
 """
-
 from astacus.common import exceptions
 from astacus.common.cachingjsonstorage import CachingJsonStorage
 from astacus.common.rohmustorage import RohmuConfig, RohmuStorage
@@ -17,7 +16,6 @@ from pathlib import Path
 from pytest_mock import MockerFixture
 from rohmu.object_storage import google
 from tests.utils import create_rohmu_config
-from unittest.mock import Mock, patch
 
 import json
 import pytest
@@ -114,9 +112,9 @@ def test_caching_storage(tmp_path: Path, mocker: MockerFixture) -> None:
     assert not mocklist.called
 
 
-@patch("rohmu.object_storage.google.get_credentials")
-@patch.object(google.GoogleTransfer, "_init_google_client")
-def test_proxy_storage(mock_google_client: Mock, mock_get_credentials: Mock) -> None:
+def test_proxy_storage(mocker: MockerFixture) -> None:
+    mocker.patch.object(google, "get_credentials")
+    mocker.patch.object(google.GoogleTransfer, "_init_google_client")
     rs = RohmuStorage(
         config=RohmuConfig.parse_obj(
             {
@@ -147,9 +145,9 @@ def test_proxy_storage(mock_google_client: Mock, mock_get_credentials: Mock) -> 
         storage="x-proxy",
     )
     assert isinstance(rs.storage, google.GoogleTransfer)
-    assert hasattr(rs.storage, "proxy_info")
-    assert rs.storage.proxy_info["user"] == "REDACTED"
-    assert rs.storage.proxy_info["pass"] == "REDACTED"
-    assert rs.storage.proxy_info["type"] == "socks5"
-    assert rs.storage.proxy_info["host"] == "localhost"
-    assert rs.storage.proxy_info["port"] == 1080
+    assert isinstance(rs.storage.proxy_info, dict)  # type: ignore[attr-defined]
+    assert rs.storage.proxy_info["user"] == "REDACTED"  # type: ignore[attr-defined]
+    assert rs.storage.proxy_info["pass"] == "REDACTED"  # type: ignore[attr-defined]
+    assert rs.storage.proxy_info["type"] == "socks5"  # type: ignore[attr-defined]
+    assert rs.storage.proxy_info["host"] == "localhost"  # type: ignore[attr-defined]
+    assert rs.storage.proxy_info["port"] == 1080  # type: ignore[attr-defined]

--- a/tests/unit/common/test_utils.py
+++ b/tests/unit/common/test_utils.py
@@ -175,8 +175,7 @@ def test_open_path_with_atomic_rename(tmp_path: Path) -> None:
     with pytest.raises(TestException):
         with utils.open_path_with_atomic_rename(f3_path):
             raise TestException()
-    # This version of MyPy works poorly with pytest.raises
-    assert not f3_path.exists()  # type: ignore[unreachable]
+    assert not f3_path.exists()
 
 
 def test_parse_umask() -> None:

--- a/tests/unit/coordinator/test_list.py
+++ b/tests/unit/coordinator/test_list.py
@@ -22,7 +22,7 @@ from astacus.coordinator import api
 from astacus.coordinator.api import get_cache_entries_from_list_response
 from astacus.coordinator.list import compute_deduplicated_snapshot_file_stats, list_backups
 from fastapi.testclient import TestClient
-from os import PathLike
+from pathlib import Path
 from pytest_mock import MockerFixture
 from tests.utils import create_rohmu_config
 from unittest import mock
@@ -222,9 +222,9 @@ def test_compute_deduplicated_snapshot_file_stats(backup_manifest: BackupManifes
     assert (num_files, total_size) == (6, 6000)
 
 
-def test_api_list_deduplication(backup_manifest: BackupManifest, tmpdir: PathLike) -> None:
+def test_api_list_deduplication(backup_manifest: BackupManifest, tmp_path: Path) -> None:
     """Test the list backup operation correctly deduplicates snapshot files when computing stats."""
-    multi_rohmu_storage = MultiRohmuStorage(config=create_rohmu_config(tmpdir))
+    multi_rohmu_storage = MultiRohmuStorage(config=create_rohmu_config(tmp_path))
     storage = multi_rohmu_storage.get_storage("x")
     storage.upload_json("backup-1", backup_manifest)
     storage.upload_hexdigest_bytes("FAKEDIGEST", b"fake-digest-data")
@@ -257,8 +257,8 @@ def test_api_list_deduplication(backup_manifest: BackupManifest, tmpdir: PathLik
     assert list_response == expected_response
 
 
-def test_list_can_use_cache_from_previous_response(backup_manifest: BackupManifest, tmpdir: PathLike) -> None:
-    multi_rohmu_storage = MultiRohmuStorage(config=create_rohmu_config(tmpdir))
+def test_list_can_use_cache_from_previous_response(backup_manifest: BackupManifest, tmp_path: Path) -> None:
+    multi_rohmu_storage = MultiRohmuStorage(config=create_rohmu_config(tmp_path))
     storage = multi_rohmu_storage.get_storage("x")
     storage.upload_json("backup-1", backup_manifest)
     storage.upload_hexdigest_bytes("FAKEDIGEST", b"fake-digest-data")
@@ -279,8 +279,8 @@ def test_list_can_use_cache_from_previous_response(backup_manifest: BackupManife
         dowload_json.assert_not_called()
 
 
-def test_list_does_not_return_stale_cache_entries(backup_manifest: BackupManifest, tmpdir: PathLike) -> None:
-    multi_rohmu_storage = MultiRohmuStorage(config=create_rohmu_config(tmpdir))
+def test_list_does_not_return_stale_cache_entries(backup_manifest: BackupManifest, tmp_path: Path) -> None:
+    multi_rohmu_storage = MultiRohmuStorage(config=create_rohmu_config(tmp_path))
     storage = multi_rohmu_storage.get_storage("x")
     storage.upload_json("backup-1", backup_manifest)
     storage.upload_hexdigest_bytes("FAKEDIGEST", b"fake-digest-data")

--- a/tests/unit/node/test_node_cassandra.py
+++ b/tests/unit/node/test_node_cassandra.py
@@ -10,9 +10,9 @@ from astacus.node.config import CassandraAccessLevel, CassandraNodeConfig
 from collections.abc import Callable, Sequence
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from httpx import Response
 from pathlib import Path
 from pytest_mock import MockerFixture
-from requests import Response
 from tests.unit.conftest import CassandraTestConfig
 from types import ModuleType
 

--- a/tests/unit/node/test_node_download.py
+++ b/tests/unit/node/test_node_download.py
@@ -99,5 +99,6 @@ def test_api_clear(client: TestClient, mocker: MockerFixture) -> None:
 
     # Decode the (result endpoint) response using the model
     response = m.call_args[1]["data"]
+    assert isinstance(response, bytes)
     result = msgspec.json.decode(response, type=ipc.NodeResult)
     assert result.progress.finished_successfully

--- a/tests/unit/storage.py
+++ b/tests/unit/storage.py
@@ -6,6 +6,7 @@ from astacus.common import exceptions
 from astacus.common.storage import HexDigestStorage, JsonStorage, StorageUploadResult
 from collections.abc import Iterator
 from pathlib import Path
+from rohmu.typing import FileLike
 from typing import BinaryIO
 
 import contextlib
@@ -52,7 +53,7 @@ class MemoryHexDigestStorage(HexDigestStorage):
     def delete_hexdigest(self, hexdigest: str) -> None:
         del self.items[hexdigest]
 
-    def download_hexdigest_to_file(self, hexdigest: str, f: BinaryIO) -> bool:
+    def download_hexdigest_to_file(self, hexdigest: str, f: FileLike) -> bool:
         f.write(self.items[hexdigest])
         return True
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -42,15 +42,15 @@ nkMAHqg9PS372Cs=
 -----END PRIVATE KEY-----"""
 
 
-def create_rohmu_config(tmpdir: os.PathLike, *, compression: bool = True, encryption: bool = True) -> RohmuConfig:
-    x_path = Path(tmpdir) / "rohmu-x"
+def create_rohmu_config(tmp_path: Path, *, compression: bool = True, encryption: bool = True) -> RohmuConfig:
+    x_path = tmp_path / "rohmu-x"
     x_path.mkdir(exist_ok=True)
-    y_path = Path(tmpdir) / "rohmu-y"
+    y_path = tmp_path / "rohmu-y"
     y_path.mkdir(exist_ok=True)
-    tmp_path = Path(tmpdir) / "rohmu-tmp"
-    tmp_path.mkdir(exist_ok=True)
+    rohmu_tmp_path = tmp_path / "rohmu-tmp"
+    rohmu_tmp_path.mkdir(exist_ok=True)
     config = {
-        "temporary_directory": str(tmp_path),
+        "temporary_directory": str(rohmu_tmp_path),
         "default_storage": "x",
         "storages": {
             "x": {

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,7 +9,6 @@ from typing import Final
 
 import importlib
 import os
-import py
 import re
 import subprocess
 import sys
@@ -43,7 +42,7 @@ nkMAHqg9PS372Cs=
 -----END PRIVATE KEY-----"""
 
 
-def create_rohmu_config(tmpdir: py.path.local, *, compression: bool = True, encryption: bool = True) -> RohmuConfig:
+def create_rohmu_config(tmpdir: os.PathLike, *, compression: bool = True, encryption: bool = True) -> RohmuConfig:
     x_path = Path(tmpdir) / "rohmu-x"
     x_path.mkdir(exist_ok=True)
     y_path = Path(tmpdir) / "rohmu-y"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,7 @@
 Copyright (c) 2020 Aiven Ltd
 See LICENSE for details
 """
-from astacus.common.rohmustorage import RohmuConfig
+from astacus.common.rohmustorage import RohmuCompressionType, RohmuConfig
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Final
@@ -64,7 +64,7 @@ def create_rohmu_config(tmpdir: os.PathLike, *, compression: bool = True, encryp
         },
     }
     if compression:
-        config.update({"compression": {"algorithm": "zstd"}})
+        config.update({"compression": {"algorithm": RohmuCompressionType.zstd}})
     if encryption:
         config.update(
             {
@@ -91,7 +91,7 @@ def get_clickhouse_version(command: Sequence[str | Path]) -> tuple[int, ...]:
 
 
 def is_cassandra_driver_importable() -> bool:
-    return importlib.util.find_spec("cassandra") is not None  # type: ignore[attr-defined]
+    return importlib.util.find_spec("cassandra") is not None
 
 
 def format_astacus_command(*arg: str) -> Sequence[str]:


### PR DESCRIPTION
The local hook allows specifying the dependencies only once, in the `pyproject.toml` file.
 This ensures they're the same at development and CI times.

Typing file helper functions and Rohmu storage methods requires changing some parameter types to use `IO[bytes]` and `FileLike`. 
These allow pass both `BinaryIO` and `_TemporaryFileWrapper[bytes]` types to the functions.

Some type errors were ignored, notably to work around Pydantic quirks (parsing of enum value, models using a discriminator field to provide union typing). 