### PR TITLE
unpin uvicorn and add optional pins

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,7 @@ jobs:
         cache: 'pip'
 
     - name: Install requirements
-      run: pip install -e '.[cassandra]'
-
-    - name: Install testing requirements (not included by default in normal install)
-      run: pip install ".[dev]"
+      run: pip install -e '.[cassandra,dev,f38]'
 
     - name: Execute unit-tests
       run: make unittest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,48 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+f38 = [
+    "cramjam == 2.8.3",
+    "cryptography == 37.0.2",
+    "fastapi == 0.99.0",
+    "h11 == 0.13.0",
+    "httpcore == 0.15.0",
+    "httplib2 == 0.20.4",
+    "httpx == 0.24.1",
+    "msgspec == 0.18.6",
+    "kazoo == 2.8.0",
+    "protobuf == 3.19.6",
+    "pydantic == 1.10.2",
+    "pyyaml == 6.0.0",
+    "requests == 2.28.2",
+    "tabulate == 0.9.0",
+    "uritemplate == 4.1.1",
+    "urllib3 == 1.26.18",
+    "uvicorn == 0.15.0",
+    "wcmatch == 8.4.1",
+    "zstandard == 0.21.0",
+]
+f39 = [
+    "cramjam == 2.8.3",
+    "cryptography == 41.0.7",
+    "fastapi == 0.103.0",
+    "h11 == 0.14.0",
+    "httpcore == 0.17.3",
+    "httplib2 == 0.21.0",
+    "httpx == 0.24.1",
+    "msgspec == 0.18.6",
+    "kazoo == 2.8.0",
+    "protobuf == 3.19.6",
+    "pydantic == 1.10.14",
+    "pyyaml == 6.0.1",
+    "requests == 2.28.2",
+    "tabulate == 0.9.0",
+    "uritemplate == 4.1.1",
+    "urllib3 == 1.26.18",
+    "uvicorn == 0.23.2",
+    "wcmatch == 8.4.1",
+    "zstandard == 0.21.0",
+]
 dev = [
     # Needed by pre-commit to lint and test the project
     "pre-commit>=3.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "sentry-sdk",
     "tabulate",
     "typing-extensions >= 4.7.1; python_version < '3.12'",
-    "uvicorn==0.15.0",
+    "uvicorn",
     "wcmatch",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+cassandra = [
+    "cassandra-driver == 3.20.2",
+]
 f38 = [
     "cramjam == 2.8.3",
     "cryptography == 37.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,10 @@ f38 = [
     "cramjam == 2.8.3",
     "cryptography == 37.0.2",
     "fastapi == 0.99.0",
-    "h11 == 0.13.0",
+    # h11 on Fedora 38 is actually 0.13.0, but 0.13.0 is rejeceted by httpcore 0.15.0
+    # See: https://github.com/encode/httpcore/blob/0.15.0/setup.py#L56-L57
+    # See also: https://github.com/python-hyper/h11/compare/v0.12.0...v0.13.0 if you're looking for meaningful differences.
+    "h11 == 0.12.0",
     "httpcore == 0.15.0",
     "httplib2 == 0.20.4",
     "httpx == 0.24.1",


### PR DESCRIPTION
Unpin uvicorn to avoid compatibility issues when installing other things.

Also add optional pinned versions: running `pip install -e .[f38]` or `f39`
(or combined  with `dev`) to get the same package versions as each Fedora version,
which helps when testing/debugging. It's also a useful reference table.

This is far from ideal, pip's version.txt would have been a better fit, but it's better than nothing.

We might want to do the same for dev dependencies if that proves to be useful.

Also repair the missing cassandra dependency (this was causing cassandra tests to not run).
