### PR TITLE
Test multiple fedora configurations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,27 +12,33 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.11"]
+        fedora-version: ["38", "39"]
+
+        include:
+          - fedora-version: "38"
+            python-version: "3.11"
+          - fedora-version: "39"
+            python-version: "3.12"
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Install dependencies
-      run: make build-dep-ubuntu test-dep-ubuntu
+      - name: Install dependencies
+        run: make build-dep-ubuntu test-dep-ubuntu
 
-    - name: Set up Python ${{ matrix.python-version }} with caching
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
+      - name: Set up Python ${{ matrix.python-version }} with caching
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
 
-    - name: Install requirements
-      run: pip install -e '.[cassandra,dev,f38]'
+      - name: Install requirements
+        run: pip install -e '.[cassandra,dev,f${{ matrix.fedora-version }}]'
 
-    - name: Execute unit-tests
-      run: make unittest
+      - name: Execute unit-tests
+        run: make unittest
 
-    - id: upload-codecov
-      # Third-party action pinned to v2.1.0
-      uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b
-      with:
-        verbose: true
+      - id: upload-codecov
+        # Third-party action pinned to v2.1.0
+        uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b
+        with:
+          verbose: true

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build-dep-fedora:
 
 .PHONY: build-dep-ubuntu
 build-dep-ubuntu:
-	sudo sh -c 'apt-get update && apt-get install -y git libsnappy-dev python3-pip python3-psycopg2 protobuf-compiler'
+	sudo sh -c 'apt-get update && apt-get install -y git libsnappy-dev python3-pip python3-psycopg2 protobuf-compiler python3-dev'
 
 .PHONY: test-dep-ubuntu
 test-dep-ubuntu:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ f39 = [
     "msgspec == 0.18.6",
     "kazoo == 2.8.0",
     "protobuf == 3.19.6",
+    "pyasyncore == 1.0.2",
     "pydantic == 1.10.14",
     "pyyaml == 6.0.1",
     "requests == 2.28.2",


### PR DESCRIPTION
It is not sufficient to exercise astacus with multiple python versions, as it is primarily used in a fedora environment with specific python packages.
Modify the CI test matrix to exercise certain fedora version python configurations, along with the correct python version which is packaged with these fedora versions.

This will help identify problems ahead of time, and better allow any issues to be addressed here, rather than via downstream patches.