### PR TITLE
Optionally ignore imbalanced AZs on `MapNode` step

### DIFF
--- a/astacus/common/exceptions.py
+++ b/astacus/common/exceptions.py
@@ -24,6 +24,10 @@ class InsufficientAZsException(PermanentException):
     pass
 
 
+class ImbalancedAZsException(PermanentException):
+    pass
+
+
 class NotFoundException(PermanentException):
     pass
 

--- a/astacus/coordinator/plugins/cassandra/plugin.py
+++ b/astacus/coordinator/plugins/cassandra/plugin.py
@@ -141,7 +141,7 @@ class CassandraPlugin(CoordinatorPlugin):
             base.BackupNameStep(json_storage=context.json_storage, requested_name=req.name),
             base.BackupManifestStep(json_storage=context.json_storage),
             restore_steps.ParsePluginManifestStep(),
-            base.MapNodesStep(partial_restore_nodes=req.partial_restore_nodes),
+            base.MapNodesStep(partial_restore_nodes=req.partial_restore_nodes, ignore_imbalanced_azs=True),
             CassandraRestoreSubOpStep(op=ipc.CassandraSubOp.stop_cassandra),
             CassandraRestoreSubOpStep(op=ipc.CassandraSubOp.unrestore_sstables),
             *cluster_restore_steps,

--- a/astacus/coordinator/plugins/m3db.py
+++ b/astacus/coordinator/plugins/m3db.py
@@ -14,6 +14,7 @@ from .base import (
     CoordinatorPlugin,
     ListHexdigestsStep,
     MapNodesStep,
+    NodeBackupIndices,
     OperationContext,
     RestoreStep,
     SnapshotStep,
@@ -191,7 +192,7 @@ def validate_m3_config(placement_nodes: Sequence[m3placement.M3PlacementNode], n
 def rewrite_m3db_placement(
     *,
     key: ETCDKey,
-    node_to_backup_index: Sequence[int | None],
+    node_to_backup_index: NodeBackupIndices,
     src_placement_nodes: Sequence[m3placement.M3PlacementNode],
     dst_placement_nodes: Sequence[m3placement.M3PlacementNode],
     nodes: Sequence[CoordinatorNode],

--- a/tests/unit/coordinator/test_restore.py
+++ b/tests/unit/coordinator/test_restore.py
@@ -9,7 +9,7 @@ from astacus.common import exceptions, ipc
 from astacus.common.ipc import Plugin
 from astacus.common.rohmustorage import MultiRohmuStorage
 from astacus.coordinator.config import CoordinatorNode
-from astacus.coordinator.plugins.base import get_node_to_backup_index
+from astacus.coordinator.plugins.base import get_node_to_backup_index, NodeBackupIndices
 from collections.abc import Callable
 from contextlib import AbstractContextManager, nullcontext as does_not_raise
 from dataclasses import dataclass


### PR DESCRIPTION
When restoring a cluster, the new nodes AZ distribution may not match the one stored in the backup manifest. In this case, the `MapNode` fails even though the new nodes may actually be better distributed now.

The change allows mapping new nodes to their backup index in the presence of imperfect match between node AZs and backup AZs. A new exception is added to identify the imbalance error and catch it.

The option to the step defaults to false so as to retain backwards compatibility with the previous behaviour.

Ideally, a better solution would be to consider an AZ imbalance metric relative to some target replication factor, instead of naively remapping the backup indices. However, let's say this is good enough for the moment.