### PR TITLE
Use different dev dependencies for different fedora versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           cache: "pip"
 
       - name: Install requirements
-        run: pip install -e '.[cassandra,dev,f${{ matrix.fedora-version }}]'
+        run: pip install -e '.[cassandra,f${{ matrix.fedora-version }}-dev,f${{ matrix.fedora-version }}]'
 
       - name: Execute lints and tests
         run: make tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ f39 = [
     "wcmatch == 8.4.1",
     "zstandard == 0.21.0",
 ]
-dev = [
+f38-dev = [
     # Needed by pre-commit to lint and test the project
     "pre-commit>=3.7.0",
     "anyio==3.5.0",
@@ -114,6 +114,28 @@ dev = [
     "coverage==7.0.5",
     "freezegun>=1.2",
     "respx==0.20.1",
+]
+
+f39-dev = [
+    # Needed by pre-commit to lint and test the project
+    "pre-commit==3.7.0",
+    "anyio==3.7.0",
+    "pylint==3.0.4",
+    "pytest-asyncio==0.23.5",
+    "pytest-cov==4.0.0",
+    "pytest-mock==3.11.1",
+    "pytest-order",
+    "pytest-timeout==2.1.0",
+    "pytest-watch==4.2.0",
+    "pytest==7.3.2",
+    "mypy==1.8.0",
+    # Types for things that don't seem to have them
+    "types-botocore>=1.0.2",
+    "types-PyYAML>=6.0.12.2",
+    "types-requests>=2.28.11.5",
+    "types-tabulate>=0.9.0.0",
+    "types-ujson>=5.9.0.0",
+    "types-urllib3>=1.26.25.4",
 ]
 
 [project.urls]


### PR DESCRIPTION
It is not sufficient to use one set of dev dependencies. In particular, pytest-asyncio has introduced a breaking change in f39.