### PR TITLE
Fix regression causing tests to not be run in GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         run: pip install -e '.[cassandra,dev,f${{ matrix.fedora-version }}]'
 
       - name: Execute lints and tests
-        run: make tests
+        run: make test
 
       - id: upload-codecov
         # Third-party action pinned to v2.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: black
 
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         files: \.py$

--- a/astacus/coordinator/plugins/clickhouse/dependencies.py
+++ b/astacus/coordinator/plugins/clickhouse/dependencies.py
@@ -3,8 +3,8 @@ Copyright (c) 2021 Aiven Ltd
 See LICENSE for details
 """
 from astacus.coordinator.plugins.clickhouse.manifest import AccessEntity, Table
-from collections.abc import Sequence
-from typing import Callable, Hashable, TypeVar
+from collections.abc import Hashable, Sequence
+from typing import Callable, TypeVar
 
 # noinspection PyCompatibility
 import graphlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ dev = [
     # Needed by pre-commit to lint and test the project
     "pre-commit>=3.7.0",
     "anyio==3.5.0",
-    "pylint==2.17.4",
+    "pylint==3.0.4",
     "pytest-cov==3.0.0",
     "pytest-mock==3.10.0",
     "pytest-order==1.0.0",


### PR DESCRIPTION
Extracted from https://github.com/Aiven-Open/astacus/pull/219 

Fixing the bug that disabled tests covered a few issues with them:
 - flake8 was failing, this is covered by the "improve linting" commit.
 - pylint was failing on f39/py3.12 deps, because pylint was still pinned to an old f38 version, bumping for both test runs it is not ideal, but #219 will provide a proper solution for that issue. Until then, it's better to run tests and have a more modern pylint than what f38 offers than not run tests at all.