### PR TITLE
disable sqlite cached statements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,8 @@ jobs:
           - fedora-version: "38"
             python-version: "3.11"
           - fedora-version: "39"
-            python-version: "3.12"
+            # https://github.com/pydantic/pydantic/issues/9637
+            python-version: "3.12.3"
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
With python 3.12 and 3.13 fetch results from SQLite3 in multi-threading applications are not consistent.

This causes an sqlite3.InterfaceError with "bad parameter or other API misuse"

Current solution is to set the cached_statement to 0. 