### PR TITLE
clickhouse: add local copy strategy for cross-provider tiered storage restore

### DIFF
--- a/astacus/coordinator/plugins/clickhouse/config.py
+++ b/astacus/coordinator/plugins/clickhouse/config.py
@@ -9,6 +9,7 @@ from astacus.coordinator.plugins.zookeeper import KazooZooKeeperClient, ZooKeepe
 from astacus.coordinator.plugins.zookeeper_config import ZooKeeperConfiguration
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import Literal
 
 import enum
 
@@ -39,9 +40,19 @@ class DiskType(enum.Enum):
     object_storage = "object_storage"
 
 
+class DirectCopyConfig(AstacusModel):
+    method: Literal["direct"] = "direct"
+
+
+class LocalCopyConfig(AstacusModel):
+    method: Literal["local"] = "local"
+    temporary_directory: str
+
+
 class DiskObjectStorageConfiguration(AstacusModel):
     default_storage: str
     storages: Mapping[str, RohmuStorageConfig]
+    copy_config: DirectCopyConfig | LocalCopyConfig = DirectCopyConfig()
 
 
 class DiskConfiguration(AstacusModel):

--- a/astacus/coordinator/plugins/clickhouse/disks.py
+++ b/astacus/coordinator/plugins/clickhouse/disks.py
@@ -41,9 +41,10 @@ class Disk:
         else:
             config_name = storage_name if storage_name is not None else config.object_storage.default_storage
             object_storage_config = config.object_storage.storages[config_name]
+            copy_config = config.object_storage.copy_config
 
             def create_storage() -> ObjectStorage:
-                return ThreadSafeRohmuStorage(config=object_storage_config)
+                return ThreadSafeRohmuStorage(config=object_storage_config, copy_config=copy_config)
 
             object_storage_factory = create_storage
         return Disk(

--- a/astacus/coordinator/plugins/clickhouse/plugin.py
+++ b/astacus/coordinator/plugins/clickhouse/plugin.py
@@ -188,8 +188,8 @@ class ClickHousePlugin(CoordinatorPlugin):
                 sync_timeout=self.sync_databases_timeout,
             ),
             MapNodesStep(partial_restore_nodes=req.partial_restore_nodes),
-            RestoreStep(storage_name=context.storage_name, partial_restore_nodes=req.partial_restore_nodes),
             RestoreObjectStorageFilesStep(source_disks=source_disks, target_disks=disks),
+            RestoreStep(storage_name=context.storage_name, partial_restore_nodes=req.partial_restore_nodes),
             AttachMergeTreePartsStep(
                 clients=clients,
                 disks=disks,

--- a/astacus/coordinator/plugins/clickhouse/steps.py
+++ b/astacus/coordinator/plugins/clickhouse/steps.py
@@ -791,7 +791,7 @@ class RestoreObjectStorageFilesStep(SyncStep[None]):
                     try:
                         if source_storage.get_config() != target_storage.get_config():
                             paths = [file.path for file in object_storage_files.files]
-                            target_storage.copy_items_from(source_storage, paths)
+                            target_storage.copy_items_from(source_storage, paths, stats=cluster.stats)
                     finally:
                         target_storage.close()
                 finally:

--- a/tests/unit/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_steps.py
@@ -1027,7 +1027,7 @@ async def test_restore_object_storage_files() -> None:
     assert target_object_storage.list_items() == object_storage_items
 
 
-async def test_restore_object_storage_files_does_nothing_is_storages_have_same_config() -> None:
+async def test_restore_object_storage_files_does_nothing_if_storages_have_same_config() -> None:
     same_object_storage = mock.Mock(spec_set=ObjectStorage)
     source_disks = Disks(disks=[create_object_storage_disk("remote", same_object_storage)])
     target_disks = Disks(disks=[create_object_storage_disk("remote", same_object_storage)])


### PR DESCRIPTION
The `copy_files_from` method is not supported between different cloud providers. Add a very simple download/upload implementation of copying between different clouds in case we need to, make it configurable, since the operator configuring Astacus is likely to know whether direct in-cloud copying is possible with the credentials/configuration they provided.