### PR TITLE
astacus: track remaining restored object files

### DIFF
--- a/astacus/coordinator/plugins/clickhouse/steps.py
+++ b/astacus/coordinator/plugins/clickhouse/steps.py
@@ -791,7 +791,11 @@ class RestoreObjectStorageFilesStep(SyncStep[None]):
                     try:
                         if source_storage.get_config() != target_storage.get_config():
                             paths = [file.path for file in object_storage_files.files]
-                            target_storage.copy_items_from(source_storage, paths, stats=cluster.stats)
+                            target_storage.copy_items_from(
+                                source_storage,
+                                paths,
+                                stats=cluster.stats,
+                            )
                     finally:
                         target_storage.close()
                 finally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "protobuf < 3.21",
     "pydantic < 2",
     "pyyaml",
-    "rohmu >= 2.5.0",
+    "rohmu >= 2.7.0",
     "sentry-sdk",
     "starlette",
     "tabulate",
@@ -134,7 +134,6 @@ source = "vcs"
 
 [tool.hatch.build.hooks.vcs]
 version-file = "astacus/version.py"
-
 
 [tool.black]
 line-length = 125

--- a/tests/unit/coordinator/plugins/clickhouse/object_storage.py
+++ b/tests/unit/coordinator/plugins/clickhouse/object_storage.py
@@ -1,0 +1,52 @@
+"""
+Copyright (c) 2024 Aiven Ltd
+See LICENSE for details
+"""
+
+
+from astacus.common.statsd import StatsClient
+from astacus.coordinator.plugins.clickhouse.object_storage import ObjectStorage, ObjectStorageItem
+from collections.abc import Sequence
+from rohmu.errors import FileNotFoundFromStorageError
+from typing import Self
+
+import dataclasses
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class MemoryObjectStorage(ObjectStorage):
+    items: dict[str, ObjectStorageItem] = dataclasses.field(default_factory=dict)
+
+    def close(self) -> None:
+        pass
+
+    @classmethod
+    def from_items(cls, items: Sequence[ObjectStorageItem]) -> Self:
+        return cls(items={item.key: item for item in items})
+
+    def get_config(self) -> dict:
+        # Exposing the object id in the config ensures that the same memory storage
+        # has the same config as itself and a different config as another memory storage.
+        # Using a manually picked name would be more error-prone: we want two object
+        # storages to share state when their config is equal (= they are reading and
+        # writing to the same place), that wouldn't happen with two identically named
+        # *memory* object storages.
+        return {"memory_id": id(self)}
+
+    def list_items(self) -> list[ObjectStorageItem]:
+        return list(self.items.values())
+
+    def delete_item(self, key: str) -> None:
+        if key not in self.items:
+            raise FileNotFoundFromStorageError(key)
+        logger.info("deleting item: %r", key)
+        self.items.pop(key)
+
+    def copy_items_from(self, source: "ObjectStorage", keys: Sequence[str], *, stats: StatsClient | None) -> None:
+        keys_set = set(keys)
+        for source_item in source.list_items():
+            if source_item.key in keys_set:
+                self.items[source_item.key] = source_item

--- a/tests/unit/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_steps.py
@@ -6,6 +6,7 @@ See LICENSE for details
 from astacus.common.asyncstorage import AsyncJsonStorage
 from astacus.common.exceptions import TransientException
 from astacus.common.ipc import BackupManifest, ManifestMin, Plugin, SnapshotFile, SnapshotResult, SnapshotState
+from astacus.common.statsd import StatsClient
 from astacus.coordinator.cluster import Cluster
 from astacus.coordinator.config import CoordinatorNode
 from astacus.coordinator.plugins.base import (
@@ -19,8 +20,10 @@ from astacus.coordinator.plugins.clickhouse.client import ClickHouseClient, Stub
 from astacus.coordinator.plugins.clickhouse.config import (
     ClickHouseConfiguration,
     ClickHouseNode,
+    DirectCopyConfig,
     DiskConfiguration,
     DiskType,
+    LocalCopyConfig,
     ReplicatedDatabaseSettings,
 )
 from astacus.coordinator.plugins.clickhouse.disks import Disk, Disks
@@ -35,7 +38,7 @@ from astacus.coordinator.plugins.clickhouse.manifest import (
     Table,
     UserDefinedFunction,
 )
-from astacus.coordinator.plugins.clickhouse.object_storage import ObjectStorage, ObjectStorageItem
+from astacus.coordinator.plugins.clickhouse.object_storage import copy_items_between, ObjectStorage, ObjectStorageItem
 from astacus.coordinator.plugins.clickhouse.replication import DatabaseReplica
 from astacus.coordinator.plugins.clickhouse.steps import (
     AttachMergeTreePartsStep,
@@ -71,12 +74,15 @@ from astacus.coordinator.plugins.clickhouse.steps import (
 )
 from astacus.coordinator.plugins.zookeeper import FakeZooKeeperClient, ZooKeeperClient
 from base64 import b64encode
-from collections.abc import Awaitable, Iterable, Sequence
+from collections.abc import Awaitable, Collection, Iterable, Sequence
 from pathlib import Path
+from rohmu import BaseTransfer
+from rohmu.object_storage.base import ObjectTransferProgressCallback
 from tests.unit.coordinator.plugins.clickhouse.object_storage import MemoryObjectStorage
 from tests.unit.storage import MemoryJsonStorage
+from typing import Any
 from unittest import mock
-from unittest.mock import _Call as MockCall  # pylint: disable=protected-access
+from unittest.mock import _Call as MockCall, patch  # pylint: disable=protected-access
 
 import asyncio
 import base64
@@ -84,6 +90,7 @@ import datetime
 import msgspec
 import pytest
 import sys
+import tempfile
 import uuid
 
 pytestmark = [pytest.mark.clickhouse]
@@ -1011,21 +1018,84 @@ async def test_restore_replica() -> None:
         check_each_pair_of_calls_has_the_same_session_id(client.mock_calls)
 
 
-async def test_restore_object_storage_files() -> None:
+@pytest.mark.parametrize("with_stats", [False, True])
+async def test_restore_object_storage_files(with_stats: bool) -> None:
+    clickhouse_source_object_storage_files = SAMPLE_MANIFEST.object_storage_files[0].files
     object_storage_items = [
         ObjectStorageItem(key=file.path, last_modified=datetime.datetime(2020, 1, 2, tzinfo=datetime.timezone.utc))
-        for file in SAMPLE_MANIFEST.object_storage_files[0].files
+        for file in clickhouse_source_object_storage_files
     ]
     source_object_storage = MemoryObjectStorage.from_items(object_storage_items)
     target_object_storage = MemoryObjectStorage()
     source_disks = Disks(disks=[create_object_storage_disk("remote", source_object_storage)])
     target_disks = Disks(disks=[create_object_storage_disk("remote", target_object_storage)])
     step = RestoreObjectStorageFilesStep(source_disks=source_disks, target_disks=target_disks)
-    cluster = Cluster(nodes=[CoordinatorNode(url="node1"), CoordinatorNode(url="node2")])
+    stats = mock.Mock(spec_set=StatsClient)
+    cluster = Cluster(
+        nodes=[CoordinatorNode(url="node1"), CoordinatorNode(url="node2")], stats=stats if with_stats else None
+    )
     context = StepsContext()
     context.set_result(ClickHouseManifestStep, SAMPLE_MANIFEST)
+
     await step.run_step(cluster, context)
+
     assert target_object_storage.list_items() == object_storage_items
+    if with_stats:
+        assert len(clickhouse_source_object_storage_files) == stats.gauge.call_count
+        assert stats.gauge.call_args_list == [
+            mock.call("astacus_copy_tiered_object_storage_files_remaining", 2, tags={"copy_method": "memory"}),
+            mock.call("astacus_copy_tiered_object_storage_files_remaining", 1, tags={"copy_method": "memory"}),
+            mock.call("astacus_copy_tiered_object_storage_files_remaining", 0, tags={"copy_method": "memory"}),
+        ]
+
+
+def _mock_copy_files_from(
+    *,
+    source: BaseTransfer[Any],
+    keys: Collection[str],
+    progress_fn: ObjectTransferProgressCallback | None = None,
+) -> None:
+    total_files = len(keys)
+    for index, _ in enumerate(keys, start=1):
+        if progress_fn is not None:
+            progress_fn(index, total_files)
+
+
+async def test_copy_items_between_with_direct_copy_method() -> None:
+    stats = mock.Mock(spec_set=StatsClient)
+    source_object_storage = mock.Mock(spec_set=BaseTransfer[Any])
+    target_object_storage = mock.Mock(spec_set=BaseTransfer[Any])
+    target_object_storage.copy_files_from = _mock_copy_files_from
+    copy_items_between(
+        keys=["key1", "key2"],
+        copy_config=DirectCopyConfig(),
+        source_storage=source_object_storage,
+        target_storage=target_object_storage,
+        stats=stats,
+    )
+    assert stats.gauge.call_args_list == [
+        mock.call("astacus_copy_tiered_object_storage_files_remaining", 1, tags={"copy_method": "direct"}),
+        mock.call("astacus_copy_tiered_object_storage_files_remaining", 0, tags={"copy_method": "direct"}),
+    ]
+
+
+async def test_copy_items_between_with_local_copy_method() -> None:
+    stats = mock.Mock(spec_set=StatsClient)
+    source_object_storage = mock.Mock(spec_set=BaseTransfer[Any])
+    target_object_storage = mock.Mock(spec_set=BaseTransfer[Any])
+    with patch.object(tempfile, "TemporaryFile") as mock_tempfile:
+        copy_items_between(
+            keys=["key1", "key2"],
+            copy_config=LocalCopyConfig(temporary_directory="tmp"),
+            source_storage=source_object_storage,
+            target_storage=target_object_storage,
+            stats=stats,
+        )
+    assert stats.gauge.call_args_list == [
+        mock.call("astacus_copy_tiered_object_storage_files_remaining", 1, tags={"copy_method": "local"}),
+        mock.call("astacus_copy_tiered_object_storage_files_remaining", 0, tags={"copy_method": "local"}),
+    ]
+    assert mock_tempfile.call_args_list == [mock.call(dir="tmp"), mock.call(dir="tmp")]
 
 
 async def test_restore_object_storage_files_does_nothing_if_storages_have_same_config() -> None:

--- a/tests/unit/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_steps.py
@@ -35,7 +35,7 @@ from astacus.coordinator.plugins.clickhouse.manifest import (
     Table,
     UserDefinedFunction,
 )
-from astacus.coordinator.plugins.clickhouse.object_storage import MemoryObjectStorage, ObjectStorage, ObjectStorageItem
+from astacus.coordinator.plugins.clickhouse.object_storage import ObjectStorage, ObjectStorageItem
 from astacus.coordinator.plugins.clickhouse.replication import DatabaseReplica
 from astacus.coordinator.plugins.clickhouse.steps import (
     AttachMergeTreePartsStep,
@@ -73,6 +73,7 @@ from astacus.coordinator.plugins.zookeeper import FakeZooKeeperClient, ZooKeeper
 from base64 import b64encode
 from collections.abc import Awaitable, Iterable, Sequence
 from pathlib import Path
+from tests.unit.coordinator.plugins.clickhouse.object_storage import MemoryObjectStorage
 from tests.unit.storage import MemoryJsonStorage
 from unittest import mock
 from unittest.mock import _Call as MockCall  # pylint: disable=protected-access


### PR DESCRIPTION
Track the progress on the remaining object storage files that needs to be copied during `RestoreObjectStorageFilesStep`.
Expose as gauge `astacus_copy_tiered_object_storage_files_remaining_value`.

Syncing required with https://github.com/Aiven-Open/astacus/pull/228

Requires rohmu 2.7.0

- https://github.com/Aiven-Open/rohmu/pull/192