### PR TITLE
seek the temp file when copying between storages

### DIFF
--- a/astacus/coordinator/plugins/clickhouse/object_storage.py
+++ b/astacus/coordinator/plugins/clickhouse/object_storage.py
@@ -119,6 +119,7 @@ def _copy_via_local_filesystem(
     for keys_copied, key in enumerate(keys):
         with tempfile.TemporaryFile(dir=copy_config.temporary_directory) as temp_file:
             metadata = source.get_contents_to_fileobj(key, temp_file)
+            temp_file.seek(0)
             target.store_file_object(key, temp_file, metadata)
         if stats:
             stats.gauge(


### PR DESCRIPTION
Rohmu download functions do not promise that the temporary file will be immediately readable after get_contents_to_fileobj exits. Seek it to the beginning of the temporary file before reading and uploading.