### PR TITLE
Clear the data directories before restoring CH

### DIFF
--- a/astacus/coordinator/plugins/clickhouse/plugin.py
+++ b/astacus/coordinator/plugins/clickhouse/plugin.py
@@ -14,6 +14,7 @@ from .config import (
 from .disks import Disks
 from .steps import (
     AttachMergeTreePartsStep,
+    ClearDisksStep,
     ClickHouseManifestStep,
     CollectObjectStorageFilesStep,
     CollectTieredStorageResultsStep,
@@ -184,6 +185,7 @@ class ClickHousePlugin(CoordinatorPlugin):
             ClickHouseManifestStep(),
             RetrieveMacrosStep(clients=clients),
             ListDatabaseReplicasStep(),
+            ClearDisksStep(disks=disks),  # clear any leftovers from previous attempts
             RestoreReplicatedDatabasesStep(
                 clients=clients,
                 replicated_databases_zookeeper_path=self.replicated_databases_zookeeper_path,

--- a/astacus/coordinator/plugins/clickhouse/steps.py
+++ b/astacus/coordinator/plugins/clickhouse/steps.py
@@ -698,6 +698,23 @@ class ListDatabaseReplicasStep(Step[DatabasesReplicas]):
 
 
 @dataclasses.dataclass
+class ClearDisksStep(Step[Sequence[ipc.NodeResult]]):
+    """
+    Request to remove all data on all ClickHouse disks.
+
+    Used to remove remnants of previous failed restore attempts.
+    """
+
+    disks: Disks
+
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> Sequence[ipc.NodeResult]:
+        root_globs = ["/".join((*disk.path_parts, "store/**/*")) for disk in self.disks.disks]
+        node_request = ipc.SnapshotClearRequest(root_globs=root_globs)
+        start_results = await cluster.request_from_nodes("clear", method="post", caller="ClearDisksStep", req=node_request)
+        return await cluster.wait_successful_results(start_results=start_results, result_class=ipc.NodeResult)
+
+
+@dataclasses.dataclass
 class SyncDatabaseReplicasStep(Step[None]):
     zookeeper_client: ZooKeeperClient
     replicated_databases_zookeeper_path: str


### PR DESCRIPTION
To avoid half-completed snapshot downloads from interfering with restore retries, remove anything from the configured disks before re-creating databases and tables.