### PR TITLE
ClickHouse: pause KeeperMap insertion momentarily during backup

### DIFF
--- a/astacus/coordinator/coordinator.py
+++ b/astacus/coordinator/coordinator.py
@@ -271,8 +271,9 @@ class SteppedCoordinatorOp(LockedCoordinatorOp):
                 with self._progress_handler(cluster, step):
                     try:
                         r = await step.run_step(cluster, context)
-                    except (StepFailedError, WaitResultError) as e:
-                        logger.info("Step %s failed: %s", step, str(e))
+                    except (StepFailedError, WaitResultError) as exc:
+                        logger.info("Step %s failed: %s", step, str(exc))
+                        await step.handle_step_failure(cluster, context)
                         return False
             context.set_result(step.__class__, r)
         return True

--- a/astacus/coordinator/plugins/base.py
+++ b/astacus/coordinator/plugins/base.py
@@ -71,13 +71,23 @@ class Step(Generic[StepResult_co]):
     async def run_step(self, cluster: Cluster, context: StepsContext) -> StepResult_co:
         raise NotImplementedError
 
+    async def handle_step_failure(self, cluster: Cluster, context: StepsContext) -> None:
+        # This method should not raise exceptions
+        return None
+
 
 class SyncStep(Step[StepResult_co]):
     async def run_step(self, cluster: Cluster, context: StepsContext) -> StepResult_co:
         return await run_in_threadpool(self.run_sync_step, cluster, context)
 
+    async def handle_step_failure(self, cluster: Cluster, context: StepsContext) -> None:
+        await run_in_threadpool(self.handle_step_failure_sync, cluster, context)
+
     def run_sync_step(self, cluster: Cluster, context: StepsContext) -> StepResult_co:
         raise NotImplementedError
+
+    def handle_step_failure_sync(self, cluster: Cluster, context: StepsContext) -> None:
+        return None
 
 
 class StepFailedError(exceptions.PermanentException):

--- a/astacus/coordinator/plugins/clickhouse/plugin.py
+++ b/astacus/coordinator/plugins/clickhouse/plugin.py
@@ -134,6 +134,7 @@ class ClickHousePlugin(CoordinatorPlugin):
             RetrieveKeeperMapTableDataStep(
                 zookeeper_client=zookeeper_client,
                 keeper_map_path_prefix=self.keeper_map_path_prefix,
+                clients=clickhouse_clients,
             ),
             # Then freeze all tables
             FreezeTablesStep(

--- a/astacus/coordinator/plugins/clickhouse/plugin.py
+++ b/astacus/coordinator/plugins/clickhouse/plugin.py
@@ -19,6 +19,7 @@ from .steps import (
     DeleteDanglingObjectStorageFilesStep,
     FreezeTablesStep,
     GetVersionsStep,
+    KeeperMapTablesReadOnlyStep,
     ListDatabaseReplicasStep,
     MoveFrozenPartsStep,
     PrepareClickHouseManifestStep,
@@ -129,6 +130,7 @@ class ClickHousePlugin(CoordinatorPlugin):
             ),
             RetrieveDatabasesAndTablesStep(clients=clickhouse_clients),
             RetrieveMacrosStep(clients=clickhouse_clients),
+            KeeperMapTablesReadOnlyStep(clients=clickhouse_clients, allow_writes=False),
             RetrieveKeeperMapTableDataStep(
                 zookeeper_client=zookeeper_client,
                 keeper_map_path_prefix=self.keeper_map_path_prefix,
@@ -137,6 +139,7 @@ class ClickHousePlugin(CoordinatorPlugin):
             FreezeTablesStep(
                 clients=clickhouse_clients, freeze_name=self.freeze_name, freeze_unfreeze_timeout=self.freeze_timeout
             ),
+            KeeperMapTablesReadOnlyStep(clients=clickhouse_clients, allow_writes=True),
             # Then snapshot and backup all frozen table parts
             SnapshotStep(
                 snapshot_groups=disks.get_snapshot_groups(self.freeze_name),

--- a/astacus/coordinator/plugins/zookeeper.py
+++ b/astacus/coordinator/plugins/zookeeper.py
@@ -11,6 +11,7 @@ from kazoo.protocol.states import KazooState
 from kazoo.recipe.watchers import ChildrenWatch, DataWatch
 from kazoo.retry import KazooRetry
 from queue import Empty, Queue
+from typing import TypeAlias
 
 import asyncio
 import contextlib
@@ -24,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 Watcher = Callable[[WatchedEvent], None]
+FaultInjection: TypeAlias = Callable[[], None]
 
 
 class ZooKeeperTransaction:
@@ -67,8 +69,9 @@ class ZooKeeperConnection:
     async def get_children_with_data(
         self,
         path: str,
-        get_data_fault: Callable[[], None] = lambda: None,
-        get_children_fault: Callable[[], None] = lambda: None,
+        *,
+        get_data_fault: FaultInjection = lambda: None,
+        get_children_fault: FaultInjection = lambda: None,
     ) -> dict[str, bytes]:
         """Returns a dictionary of all children of the given `path` with their data.
 

--- a/tests/unit/coordinator/plugins/clickhouse/test_steps.py
+++ b/tests/unit/coordinator/plugins/clickhouse/test_steps.py
@@ -283,10 +283,25 @@ async def create_zookeeper_keeper_map_table_data(zookeeper_client: ZooKeeperClie
 
 async def test_retrieve_keeper_map_table_data() -> None:
     zookeeper_client = FakeZooKeeperClient()
+    clickhouse_client = mock_clickhouse_client()
     await create_zookeeper_keeper_map_table_data(zookeeper_client)
     step = RetrieveKeeperMapTableDataStep(
         zookeeper_client=zookeeper_client,
         keeper_map_path_prefix="/clickhouse/keeper_map/",
+        clients=[clickhouse_client],
+    )
+    keeper_map_data = await step.run_step(Cluster(nodes=[]), StepsContext())
+    assert keeper_map_data == SAMPLE_KEEPER_MAP_TABLES
+
+
+async def test_retrieve_keeper_map_table_data_raises_step_error_on_zookeeper_error() -> None:
+    zookeeper_client = FakeZooKeeperClient()
+    clickhouse_client = mock_clickhouse_client()
+    await create_zookeeper_keeper_map_table_data(zookeeper_client)
+    step = RetrieveKeeperMapTableDataStep(
+        zookeeper_client=zookeeper_client,
+        keeper_map_path_prefix="/clickhouse/keeper_map/",
+        clients=[clickhouse_client],
     )
     keeper_map_data = await step.run_step(Cluster(nodes=[]), StepsContext())
     assert keeper_map_data == SAMPLE_KEEPER_MAP_TABLES

--- a/tests/unit/coordinator/test_coordinator.py
+++ b/tests/unit/coordinator/test_coordinator.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2024 Aiven Ltd
+from astacus.common.ipc import Plugin
+from astacus.common.statsd import StatsClient
+from astacus.coordinator.cluster import Cluster, WaitResultError
+from astacus.coordinator.config import CoordinatorConfig
+from astacus.coordinator.coordinator import Coordinator, SteppedCoordinatorOp
+from astacus.coordinator.plugins.base import Step, StepFailedError, StepsContext
+from astacus.coordinator.state import CoordinatorState
+from collections.abc import Callable
+from fastapi import BackgroundTasks
+from starlette.datastructures import URL
+from typing import TypeAlias
+from unittest.mock import Mock
+
+import dataclasses
+import pytest
+
+ExceptionClosure: TypeAlias = Callable[[], Exception]
+
+
+@dataclasses.dataclass
+class FailingDummyStep(Step[None]):
+    raised_exception: ExceptionClosure
+    failure_handled: bool = dataclasses.field(init=False, default=False)
+
+    async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
+        raise self.raised_exception()
+
+    async def handle_step_failure(self, cluster: Cluster, context: StepsContext) -> None:
+        self.failure_handled = True
+
+
+@pytest.mark.parametrize("raised_exception", [lambda: StepFailedError, lambda: WaitResultError])
+async def test_failure_handler_is_called(raised_exception: ExceptionClosure) -> None:
+    coordinator = Coordinator(
+        request_url=URL(),
+        background_tasks=BackgroundTasks(),
+        config=CoordinatorConfig(plugin=Plugin.files),
+        state=CoordinatorState(),
+        stats=StatsClient(config=None),
+        storage_factory=Mock(),
+    )
+    dummy_step = FailingDummyStep(raised_exception=raised_exception)
+    operation = SteppedCoordinatorOp(
+        c=coordinator,
+        attempts=1,
+        steps=[dummy_step],
+        operation_context=Mock(),
+    )
+    cluster = Cluster(nodes=[])
+    context = StepsContext()
+    result = await operation.try_run(cluster, context)
+    assert dummy_step.failure_handled
+    assert not result


### PR DESCRIPTION
The PR alters replicated users' privileges (through GRANT & REVOKE) during the backup. This ensures the KeeperMap tables' snapshot is consistent with the frozen table data.

[DDB-1237]