### PR TITLE
Only execute access rights change queries on a single node

### DIFF
--- a/astacus/coordinator/plugins/clickhouse/steps.py
+++ b/astacus/coordinator/plugins/clickhouse/steps.py
@@ -190,14 +190,14 @@ class KeeperMapTablesReadOnlyStep(Step[None]):
         revoke_statement = (
             f"REVOKE INSERT, ALTER UPDATE, ALTER DELETE ON {table.escaped_sql_identifier} FROM {escaped_user_name}"
         )
-        await asyncio.gather(*(client.execute(revoke_statement.encode()) for client in self.clients))
+        await self.clients[0].execute(revoke_statement.encode())
 
     async def grant_write_on_table(self, table: Table, user_name: bytes) -> None:
         escaped_user_name = escape_sql_identifier(user_name)
         grant_statement = (
             f"GRANT INSERT, ALTER UPDATE, ALTER DELETE ON {table.escaped_sql_identifier} TO {escaped_user_name}"
         )
-        await asyncio.gather(*(client.execute(grant_statement.encode()) for client in self.clients))
+        await self.clients[0].execute(grant_statement.encode())
 
     async def run_step(self, cluster: Cluster, context: StepsContext) -> None:
         _, tables = context.get_result(RetrieveDatabasesAndTablesStep)


### PR DESCRIPTION
For the read-only step, we're filtering by replicated users, whose grant information is stored in ZooKeeper.

This means that executing the query on multiple nodes is counterproductive. Instead of achieving faster information propagation, we're getting transaction errors from ZooKeeper. Any one of these can in turn fail the step.

Here's one such example:
```
Query failed: b'REVOKE INSERT, ALTER UPDATE, ALTER DELETE ON `default`.`keeper_map` FROM `alice`' on <host>:
status_code=500,
exception_code=999,
response=b'Code: 999. Coordination::Exception: Transaction failed: Op #0, path: /clickhouse/access/uuid/914a9caa-682f-5dce-4ed7-b0f16f564798. (KEEPER_EXCEPTION) (version 24.3.5.1)\n'
```